### PR TITLE
Pull microsoft docker images in testbed template

### DIFF
--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -44,6 +44,7 @@
   win_shell: "docker pull {{ item }}"
   with_items:
       - microsoft/nanoserver
+      - microsoft/windowsservercore
 
 - name: Install MS Visuall C++ Redist 14
   win_chocolatey:

--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -40,6 +40,11 @@
 - name: Install Docker-EE
   win_shell: "Install-Package Docker -ProviderName DockerProvider -Force"
 
+- name: Pull docker images
+  win_shell: "docker pull {{ item }}"
+  with_items:
+      - microsoft/nanoserver
+
 - name: Install MS Visuall C++ Redist 14
   win_chocolatey:
     name: vcredist140


### PR DESCRIPTION
The goal is for testbeds not to have network connection, so we should do it in template.