### PR TITLE
Run vtest case-by-case and disable outdated tests

### DIFF
--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -93,6 +93,7 @@ function Disable-VRouterExtension {
 
     Invoke-Command -Session $Session -ScriptBlock {
         Disable-VMSwitchExtension -VMSwitchName $Using:VMSwitchName -Name $Using:ForwardingExtensionName -ErrorAction SilentlyContinue | Out-Null
+        Get-ContainerNetwork | Where-Object NetworkAdapterName -eq $Using:AdapterName | Remove-ContainerNetwork -ErrorAction SilentlyContinue -Force
         Get-ContainerNetwork | Where-Object NetworkAdapterName -eq $Using:AdapterName | Remove-ContainerNetwork -Force
     }
 }

--- a/CIScripts/Test/Tests/Integration/VTestScenarios.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/VTestScenarios.Tests.ps1
@@ -15,28 +15,83 @@ $TestConf = Get-TestConfiguration
 $Sessions = New-RemoteSessions -VMs (Read-TestbedsConfig -Path $TestenvConfFile)
 $Session = $Sessions[0]
 
+function Test-IsScenarioOutdated {
+    Param ([Parameter(Mandatory=$true)] [string] $TestData)
+
+    $NH_FLAG_ENCAP_L2 = 4
+
+    [xml] $Xml = $TestData
+
+    $BadFlags = $Xml | Select-Xml -Xpath //test/message/vr_nexthop_req/nhr_flags `
+        | Where-Object { $_.Node.InnerText -BAnd $NH_FLAG_ENCAP_L2 }
+
+    return [bool] $BadFlags
+}
+
+$TestsDir = "C:\Artifacts\vtest\tests\"
+
+$Tests = Invoke-Command -Session $Session {
+    Get-ChildItem -Path $Using:TestsDir -Filter *.xml -Recurse
+} | Foreach-Object {
+    @{
+        Name = $_.FullName.Substring($TestsDir.Length)
+        Path = $_.FullName
+    }
+}
+
 Describe "vTest scenarios" {
-    It "passes all vtest scenarios" {
-        $VMSwitchName = $TestConf.VMSwitchName
-        {
-            Invoke-Command -Session $Session -ScriptBlock {
-                Push-Location C:\Artifacts\
-                .\vtest\all_tests_run.ps1 -VMSwitchName $Using:VMSwitchName `
-                    -TestsFolder vtest\tests
-                Pop-Location
-            }
-        } | Should Not Throw
+    It "passes <Name>" -TestCases $Tests {
+        param($Name, $Path)
+
+        $TestData = Invoke-Command -Session $Session {
+            Get-Content $Using:Path -Raw
+        }
+
+        if (Test-IsScenarioOutdated $TestData) {
+            Set-TestInconclusive -Message "The test is using removed NH_FLAG_ENCAP_L2"
+            return
+        }
+
+        $ExitCode = Invoke-Command -Session $Session -ScriptBlock {
+
+            $Ret = Start-Process -File vtest.exe `
+                -RedirectStandardOutput $Using:OutFile `
+                -RedirectStandardError $Using:ErrFile `
+                -Wait -PassThru -WindowStyle Hidden -ArgumentList $Using:Path
+
+            Get-Content $Using:OutFile | Write-Host
+            Get-Content $Using:ErrFile | Write-Warning
+
+            $Ret.ExitCode
+        }
+        $ExitCode | Should Be 0
     }
 
-    BeforeAll {
-        Install-Extension -Session $Session
-        Install-Utils -Session $Session
+    BeforeEach {
         Enable-VRouterExtension -Session $Session -AdapterName $TestConf.AdapterName `
             -VMSwitchName $TestConf.VMSwitchName `
             -ForwardingExtensionName $TestConf.ForwardingExtensionName
     }
 
+    AfterEach {
+        Disable-VRouterExtension -Session $Session -AdapterName $TestConf.AdapterName `
+            -VMSwitchName $TestConf.VMSwitchName `
+            -ForwardingExtensionName $TestConf.ForwardingExtensionName
+    }
+
+    BeforeAll {
+        Invoke-Command -Session $Session { Push-Location C:\Artifacts }
+        Install-Extension -Session $Session
+        Install-Utils -Session $Session
+
+        $OutFile, $ErrFile = Invoke-Command -Session $Session {
+            "$Env:Temp/vtest-stdout.log"
+            "$Env:Temp/vtest-stderr.log"
+        }
+    }
+
     AfterAll {
+        Invoke-Command -Session $Session { Pop-Location }
         Clear-TestConfiguration -Session $Session -TestConfiguration $TestConf
         Uninstall-Utils -Session $Session
         Uninstall-Extension -Session $Session


### PR DESCRIPTION
Stop using the `all_tests_run.ps1` script, but run the tests directly from Pester.

Also, mark the tests that use `NH_FLAG_ENCAP_L2` in `vr_nexthop_req` as *inconclusive* (temporarily)