### PR TITLE
Exclude PSAvoidUsingPlainTextForPassword rule from PSScriptAnalyzer

### DIFF
--- a/CIScripts/Build/BuildFunctions.ps1
+++ b/CIScripts/Build/BuildFunctions.ps1
@@ -22,8 +22,6 @@ function Initialize-BuildEnvironment {
 }
 
 function Set-MSISignature {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-        "CertPasswordFilePath", Justification="It's filepath, not password.")]
     Param ([Parameter(Mandatory = $true)] [string] $SigntoolPath,
            [Parameter(Mandatory = $true)] [string] $CertPath,
            [Parameter(Mandatory = $true)] [string] $CertPasswordFilePath,
@@ -37,8 +35,6 @@ function Set-MSISignature {
 }
 
 function Invoke-DockerDriverBuild {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-        "CertPasswordFilePath", Justification="It's filepath, not password.")]
     Param ([Parameter(Mandatory = $true)] [string] $DriverSrcPath,
            [Parameter(Mandatory = $true)] [string] $SigntoolPath,
            [Parameter(Mandatory = $true)] [string] $CertPath,
@@ -125,8 +121,6 @@ function Invoke-DockerDriverBuild {
 }
 
 function Invoke-ExtensionBuild {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-        "CertPasswordFilePath", Justification="It's filepath, not password.")]
     Param ([Parameter(Mandatory = $true)] [string] $ThirdPartyCache,
            [Parameter(Mandatory = $true)] [string] $SigntoolPath,
            [Parameter(Mandatory = $true)] [string] $CertPath,
@@ -197,8 +191,6 @@ function Copy-VtestScenarios {
 }
 
 function Invoke-AgentBuild {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-        "CertPasswordFilePath", Justification="It's filepath, not password.")]
     Param ([Parameter(Mandatory = $true)] [string] $ThirdPartyCache,
            [Parameter(Mandatory = $true)] [string] $SigntoolPath,
            [Parameter(Mandatory = $true)] [string] $CertPath,

--- a/CIScripts/Common/VMUtils.ps1
+++ b/CIScripts/Common/VMUtils.ps1
@@ -30,8 +30,6 @@ function Get-UsernameInWorkgroup {
 }
 
 function New-RemoteSessions {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "Creds",
-        Justification="Complains that it's plaintext. It's not.")]
     Param ([Parameter(Mandatory = $true)] [Hashtable[]] $VMs)
 
     $Sessions = [System.Collections.ArrayList] @()

--- a/CIScripts/Test/Tests/_Old_Tests/ComputeControllerIntegrationTests.ps1
+++ b/CIScripts/Test/Tests/_Old_Tests/ComputeControllerIntegrationTests.ps1
@@ -33,8 +33,6 @@ function Test-ComputeControllerIntegration {
             "", Justification="This are just credentials to a testbed controller.")]
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingUserNameAndPassWordParams",
             Justification="We don't care that it's plaintext, it's just test env.")]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-            "Password", Justification="We don't care that it's plaintext, it's just test env.")]
         Param ([Parameter(Mandatory = $true)] [string] $IP,
                [Parameter(Mandatory = $true)] [string] $Username,
                [Parameter(Mandatory = $true)] [string] $Password)

--- a/CIScripts/Test/Tests/_Old_Tests/SNATTest.ps1
+++ b/CIScripts/Test/Tests/_Old_Tests/SNATTest.ps1
@@ -169,8 +169,6 @@ function Test-SNAT {
          "", Justification="This are just credentials to a testbed endhost.")]
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingUserNameAndPassWordParams",
             Justification="We don't care that it's plaintext, it's just test env.")]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-            "EndhostPassword", Justification="We don't care that it's plaintext, it's just test env.")]
         Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
                [Parameter(Mandatory = $true)] [string] $PhysicalMac,
                [Parameter(Mandatory = $true)] [string] $EndhostIP,

--- a/CIScripts/Test/Utils/ContrailUtils.ps1
+++ b/CIScripts/Test/Utils/ContrailUtils.ps1
@@ -3,8 +3,6 @@ $CONVERT_TO_JSON_MAX_DEPTH = 100
 function Get-AccessTokenFromKeystone {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingUserNameAndPassWordParams",
         Justification="We don't care that it's plaintext, it's just test env.")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-        "Password", Justification="We don't care that it's plaintext, it's just test env.")]
     Param ([Parameter(Mandatory = $true)] [string] $AuthUrl,
            [Parameter(Mandatory = $true)] [string] $TenantName,
            [Parameter(Mandatory = $true)] [string] $Username,

--- a/CIScripts/Test/Utils/RegisterDefaultResorces.ps1
+++ b/CIScripts/Test/Utils/RegisterDefaultResorces.ps1
@@ -3,8 +3,6 @@
 function Register-DefaultResourcesInContrail {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingUserNameAndPassWordParams",
         Justification="We don't care that it's plaintext, it's just test env.")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",
-        "Password", Justification="We don't care that it's plaintext, it's just test env.")]
     Param (
         [Parameter(Mandatory = $true)] [string] $ContrailIp,
         [string] $TenantName = "admin",

--- a/StaticAnalysis/PSScriptAnalyzerSettings.psd1
+++ b/StaticAnalysis/PSScriptAnalyzerSettings.psd1
@@ -5,6 +5,7 @@
         "PSAvoidUsingInvokeExpression", # We don't have an alternative for this yet.
         "PSUseShouldProcessForStateChangingFunctions",      # We don't care about altering system state.
         "PSUseSingularNouns",           # We sometimes like using plural nouns.
-        "PSAvoidUsingWMICmdlet"         # We tend to use WMI to access advanced Hyper-V features.
+        "PSAvoidUsingWMICmdlet",        # We tend to use WMI to access advanced Hyper-V features.
+        "PSAvoidUsingPlainTextForPassword"      # We use credentials in testenv as a plaintext
     )
 }

--- a/StaticAnalysis/PSScriptAnalyzerSettings.psd1
+++ b/StaticAnalysis/PSScriptAnalyzerSettings.psd1
@@ -6,6 +6,6 @@
         "PSUseShouldProcessForStateChangingFunctions",      # We don't care about altering system state.
         "PSUseSingularNouns",           # We sometimes like using plural nouns.
         "PSAvoidUsingWMICmdlet",        # We tend to use WMI to access advanced Hyper-V features.
-        "PSAvoidUsingPlainTextForPassword"      # We use credentials in testenv as a plaintext
+        "PSAvoidUsingPlainTextForPassword"      # We use credentials in testenv as a plaintext.
     )
 }


### PR DESCRIPTION
Ecxlude this rule due to bug with 0SCreds variable in testenv (SuppressMessage doesn't work)