### PR TITLE
Disable utils-based tests

### DIFF
--- a/CIScripts/Test/Tests/Protocol/SingleHostWithUtils.Tests.ps1
+++ b/CIScripts/Test/Tests/Protocol/SingleHostWithUtils.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Single compute node protocol tests with utils" {
     }
 
     Context "ICMP" {
-        It "Ping between containers succeeds" {
+        It "Ping between containers succeeds" -Pending {
             Invoke-Command -Session $Session -ScriptBlock {
                 $Container2IP = $Using:Container2NetInfo.IPAddress
                 docker exec $Using:Container1ID powershell "ping $Container2IP > null 2>&1; `$LASTEXITCODE;"


### PR DESCRIPTION
Flags for nh.exe have changed so the tests are broken on master.

Disable utils-based tests so we can enable building Extension in CI.
After enabling Extension, they will be fixed and reenabled.