### PR TITLE
Add optional -Session parameter to Invoke-NativeCommand

### DIFF
--- a/CIScripts/Build/BuildFunctions.ps1
+++ b/CIScripts/Build/BuildFunctions.ps1
@@ -262,7 +262,7 @@ function Invoke-AgentUnitTestRunner {
     Param ([Parameter(Mandatory = $true)] [String] $TestExecutable)
     Write-Host "===> Agent tests: running $TestExecutable..."
     $Res = Invoke-Command -ScriptBlock {
-        $NativeCommandReturn = Invoke-NativeCommand -AllowNonZero -CaptureOutput -ScriptBlock {
+        $Command = Invoke-NativeCommand -AllowNonZero -CaptureOutput -ScriptBlock {
             Invoke-Expression $TestExecutable
         }
 
@@ -271,11 +271,11 @@ function Invoke-AgentUnitTestRunner {
         # Even if all tests actually pass, test executables can sometimes
         # return non-zero exit code.
         # TODO: It should be removed once the bug is fixed (JW-1110).
-        $SeemsLegitimate = Test-IfGTestOutputSuggestsThatAllTestsHavePassed -TestOutput $NativeCommandReturn.Output
-        if ($NativeCommandReturn.ExitCode -eq 0 -or $SeemsLegitimate) {
+        $SeemsLegitimate = Test-IfGTestOutputSuggestsThatAllTestsHavePassed -TestOutput $Command.Output
+        if ($Command.ExitCode -eq 0 -or $SeemsLegitimate) {
             return 0
         } else {
-            return $ExitCode
+            return $Command.ExitCode
         }
     }
 

--- a/CIScripts/Build/BuildFunctions.ps1
+++ b/CIScripts/Build/BuildFunctions.ps1
@@ -262,7 +262,7 @@ function Invoke-AgentUnitTestRunner {
     Param ([Parameter(Mandatory = $true)] [String] $TestExecutable)
     Write-Host "===> Agent tests: running $TestExecutable..."
     $Res = Invoke-Command -ScriptBlock {
-        $NativeCommandReturn = Invoke-NativeCommand -AllowNonZero $true -ScriptBlock {
+        $NativeCommandReturn = Invoke-NativeCommand -AllowNonZero -ScriptBlock {
             Invoke-Expression $TestExecutable
         }
         $ExitCode = $NativeCommandReturn[-1]

--- a/CIScripts/Build/BuildFunctions.ps1
+++ b/CIScripts/Build/BuildFunctions.ps1
@@ -262,19 +262,17 @@ function Invoke-AgentUnitTestRunner {
     Param ([Parameter(Mandatory = $true)] [String] $TestExecutable)
     Write-Host "===> Agent tests: running $TestExecutable..."
     $Res = Invoke-Command -ScriptBlock {
-        $NativeCommandReturn = Invoke-NativeCommand -AllowNonZero -ScriptBlock {
+        $NativeCommandReturn = Invoke-NativeCommand -AllowNonZero -CaptureOutput -ScriptBlock {
             Invoke-Expression $TestExecutable
         }
-        $ExitCode = $NativeCommandReturn[-1]
-        $TestOutput = $NativeCommandReturn[0..($NativeCommandReturn.Length-2)]
 
         # This is a workaround for the following bug:
         # https://bugs.launchpad.net/opencontrail/+bug/1714205
         # Even if all tests actually pass, test executables can sometimes
         # return non-zero exit code.
         # TODO: It should be removed once the bug is fixed (JW-1110).
-        $SeemsLegitimate = Test-IfGTestOutputSuggestsThatAllTestsHavePassed -TestOutput $TestOutput
-        if ($ExitCode -eq 0 -or $SeemsLegitimate) {
+        $SeemsLegitimate = Test-IfGTestOutputSuggestsThatAllTestsHavePassed -TestOutput $NativeCommandReturn.Output
+        if ($NativeCommandReturn.ExitCode -eq 0 -or $SeemsLegitimate) {
             return 0
         } else {
             return $ExitCode

--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -93,6 +93,11 @@ Describe "Invoke-NativeCommand" {
             INC { Write-Error "simulated stderr"; whoami.exe }
             (Get-WriteHostOutput)[0] | Should BeLike '*stderr*'
         }
+
+        It "doesn't leave a trace of LastExitCode" {
+            INC -ScriptBlock { whoami.exe }
+            $LastExitCode | Should BeNullOrEmpty
+        }
     }
 
     Context "Local machine" {

--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -1,14 +1,21 @@
+Param (
+    [Parameter(Mandatory=$true)] [string] $TestenvConfFile
+)
+
 . $PSScriptRoot/Init.ps1
+. $PSScriptRoot/../Testenv/Testenv.ps1
+. $PSScriptRoot/VMUtils.ps1
+
 . $PSScriptRoot/Invoke-NativeCommand.ps1
 
 Describe "Invoke-NativeCommand" {
     Context "Local machine" {
         It "does not throw on successful command" {
-            { Invoke-NativeCommand { whoami.exe } } | Should Not Throw
+            Invoke-NativeCommand { whoami.exe }
         }
 
         It "can accept the scriptblock also as an explicit parameter" {
-            { Invoke-NativeCommand -CaptureOutput -ScriptBlock { whoami.exe } } | Should Not Throw
+            Invoke-NativeCommand -CaptureOutput -ScriptBlock { whoami.exe }
         }
 
         It "throws on failed command" {
@@ -20,7 +27,8 @@ Describe "Invoke-NativeCommand" {
         }
 
         It "captures the exitcode of successful command" {
-            (Invoke-NativeCommand -AllowNonZero { whoami.exe }).ExitCode | Should Be 0
+            $Result = Invoke-NativeCommand -AllowNonZero { whoami.exe }
+            $Result.ExitCode | Should Be 0
         }
 
         It "captures the exitcode a failed command" {
@@ -42,6 +50,67 @@ Describe "Invoke-NativeCommand" {
         It "can use variables it scriptblock" {
             $Command = "whoami.exe"
             (Invoke-NativeCommand -CaptureOutput -AllowNonZero { & $Command }).ExitCode | Should Be 0
+        }
+
+        It "preserves the ErrorActionPreference" {
+            $ErrorActionPreference = "Stop"
+            Invoke-NativeCommand -CaptureOutput { whoami.exe } | Out-Null
+            $ErrorActionPreference | Should Be "Stop"
+        }
+    }
+
+    Context "Remote machine" {
+        BeforeAll {
+            $Sessions = New-RemoteSessions -VMs (Read-TestbedsConfig -Path $TestenvConfFile)
+            $Session = $Sessions[0]
+        }
+
+        It "does not throw on successful command" {
+            Invoke-NativeCommand -Session $Session { whoami.exe }
+        }
+
+        It "can accept the scriptblock also as an explicit parameter" {
+            Invoke-NativeCommand -Session $Session -CaptureOutput -ScriptBlock { whoami.exe }
+        }
+
+        It "throws on failed command" {
+            { Invoke-NativeCommand -Session $Session { whoami.exe /invalid_parameter } } | Should Throw
+        }
+
+        It "throws on nonexisting command" {
+            { Invoke-NativeCommand -Session $Session { asdfkljasdsdf.exe } } | Should Throw
+        }
+
+        It "captures the exitcode of successful command" {
+            $Result = Invoke-NativeCommand -Session $Session -AllowNonZero { whoami.exe }
+            $Result.ExitCode | Should Be 0
+        }
+
+        It "captures the exitcode a failed command" {
+            (Invoke-NativeCommand -Session $Session -AllowNonZero { whoami.exe /invalid }).ExitCode | Should Not Be 0
+        }
+
+        It "can capture the output of a command" {
+            (Invoke-NativeCommand -Session $Session -CaptureOutput { whoami.exe }).Output | Should BeLike '*\*'
+        }
+
+        It "can capture multiline output" {
+            (Invoke-NativeCommand -Session $Session -CaptureOutput { whoami.exe /? }).Output.Count | Should BeGreaterThan 1
+        }
+
+        It "does not capture the output by default" {
+            Invoke-NativeCommand -Session $Session { whoami.exe } | Should BeNullOrEmpty
+        }
+
+        It "can use variables it scriptblock" {
+            $Command = "whoami.exe"
+            (Invoke-NativeCommand -Session $Session -CaptureOutput -AllowNonZero { & $Using:Command }).ExitCode | Should Be 0
+        }
+
+        It "preserves the ErrorActionPreference" {
+            $OldEA = Invoke-Command -Session $Session { $ErrorActionPreference }
+            Invoke-NativeCommand -Session $Session -CaptureOutput { whoami.exe } | Out-Null
+            Invoke-Command -Session $Session { $ErrorActionPreference } | Should Be $OldEA
         }
     }
 }

--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -1,0 +1,25 @@
+. $PSScriptRoot/Invoke-NativeCommand.ps1
+
+Describe "Invoke-NativeCommand" {
+    Context "Local machine" {
+        It "does not throw on successful command" {
+            { Invoke-NativeCommand { whoami.exe } } | Should Not Throw
+        }
+
+        It "throws on failed command" {
+            { Invoke-NativeCommand { whoami.exe /invalid_parameter } } | Should Throw
+        }
+
+        It "captures the exitcode of successful command" {
+            (Invoke-NativeCommand -AllowNonZero { whoami.exe })[-1] | Should Be 0
+        }
+
+        It "captures the exitcode a failed command" {
+            (Invoke-NativeCommand -AllowNonZero { whoami.exe /invalid })[-1] | Should Not Be 0
+        }
+
+        It "can capture the output of a command" {
+            Invoke-NativeCommand { whoami.exe } | Should BeLike '*\*'
+        }
+    }
+}

--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -62,6 +62,11 @@ Describe "Invoke-NativeCommand" {
     Context "Remote machine" {
         BeforeAll {
             $Sessions = New-RemoteSessions -VMs (Read-TestbedsConfig -Path $TestenvConfFile)
+            [
+                Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments",
+                "Session",
+                Justification="PSAnalyzer doesn't understand relations of Pester's blocks.")
+            ]
             $Session = $Sessions[0]
         }
 

--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -9,9 +9,25 @@ Param (
 . $PSScriptRoot/Invoke-NativeCommand.ps1
 
 Describe "Invoke-NativeCommand" {
+    BeforeAll {
+        Mock Write-Host {
+            param([Parameter(ValueFromPipeline = $true)] $Object)
+            $Script:WriteHostOutput += $Object
+        }
+
+        function Get-WriteHostOutput {
+            $Script:WriteHostOutput
+        }
+    }
+
+    BeforeEach {
+        $Script:WriteHostOutput = @()
+    }
+
     Context "Local machine" {
-        It "does not throw on successful command" {
+        It "works on a simple case" {
             Invoke-NativeCommand { whoami.exe }
+            Get-WriteHostOutput | Should BeLike '*\*'
         }
 
         It "can accept the scriptblock also as an explicit parameter" {

--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot/Init.ps1
 . $PSScriptRoot/Invoke-NativeCommand.ps1
 
 Describe "Invoke-NativeCommand" {
@@ -6,20 +7,41 @@ Describe "Invoke-NativeCommand" {
             { Invoke-NativeCommand { whoami.exe } } | Should Not Throw
         }
 
+        It "can accept the scriptblock also as an explicit parameter" {
+            { Invoke-NativeCommand -CaptureOutput -ScriptBlock { whoami.exe } } | Should Not Throw
+        }
+
         It "throws on failed command" {
             { Invoke-NativeCommand { whoami.exe /invalid_parameter } } | Should Throw
         }
 
+        It "throws on nonexisting command" {
+            { Invoke-NativeCommand { asdfkljasdsdf.exe } } | Should Throw
+        }
+
         It "captures the exitcode of successful command" {
-            (Invoke-NativeCommand -AllowNonZero { whoami.exe })[-1] | Should Be 0
+            (Invoke-NativeCommand -AllowNonZero { whoami.exe }).ExitCode | Should Be 0
         }
 
         It "captures the exitcode a failed command" {
-            (Invoke-NativeCommand -AllowNonZero { whoami.exe /invalid })[-1] | Should Not Be 0
+            (Invoke-NativeCommand -AllowNonZero { whoami.exe /invalid }).ExitCode | Should Not Be 0
         }
 
         It "can capture the output of a command" {
-            Invoke-NativeCommand { whoami.exe } | Should BeLike '*\*'
+            (Invoke-NativeCommand -CaptureOutput { whoami.exe }).Output | Should BeLike '*\*'
+        }
+
+        It "can capture multiline output" {
+            (Invoke-NativeCommand -CaptureOutput { whoami.exe /? }).Output.Count | Should BeGreaterThan 1
+        }
+
+        It "does not capture the output by default" {
+            Invoke-NativeCommand { whoami.exe } | Should BeNullOrEmpty
+        }
+
+        It "can use variables it scriptblock" {
+            $Command = "whoami.exe"
+            (Invoke-NativeCommand -CaptureOutput -AllowNonZero { & $Command }).ExitCode | Should Be 0
         }
     }
 }

--- a/CIScripts/Common/Invoke-NativeCommand.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.ps1
@@ -1,6 +1,8 @@
+. $PSScriptRoot/Aliases.ps1
 function Invoke-NativeCommand {
     Param (
         [Parameter(Mandatory = $true)] [ScriptBlock] $ScriptBlock,
+        [Parameter(Mandatory = $false)] [PSSessionT] $Session,
         [Switch] $AllowNonZero,
         [Switch] $CaptureOutput
     )
@@ -19,48 +21,84 @@ function Invoke-NativeCommand {
     # because Jenkins misinterprets $LastExitCode variable.
     #
     # Note: The command has to return 0 exitcode to be considered successful.
-
+    #
     # The wrapper returns a dictionary with a two optional fields:
     # If -AllowNonZero is set, the .ExitCode contains an exitcode of a command.
     # If -CaputerOutput is set, the .Output contains captured output
     # (otherwise, it will be printed usint Write-Host)
 
-    # If an executable in $ScriptBlock wouldn't be found then while checking $LastExitCode
-    # we would be checking the exit code of a previous command. To avoid this we clear $LastExitCode.
-    $Global:LastExitCode = $null
+    function Invoke-CommandLocalOrRemote {
+        Param(
+            [parameter(Mandatory=$true)] [AllowNull()] [PSSessionT] $Session,
+            [parameter(Mandatory=$true)] [ScriptBlock] $ScriptBlock
+        )
 
-    $ReturnDict = @{}
-
-    $Output = @()
-    $Output += Invoke-Command {
-        # Since we're redirecting stderr to stdout we shouldn't have to set ErrorActionPreference
-        # but because of a bug in Powershell we have to.
-        # https://github.com/PowerShell/PowerShell/issues/4002
-        $ErrorActionPreference = "Continue"
-
-        # We redirect stderr to stdout so nothing is added to $Error.
-        # We do this to be compliant to durable-task-plugin 1.18.
-        if ($CaptureOutput) {
-            & $ScriptBlock 2>&1
+        if ($Session) {
+            Invoke-Command -Session $Session -ScriptBlock $ScriptBlock
         } else {
-            & $ScriptBlock 2>&1 | Write-Host
+            Invoke-Command -ScriptBlock $ScriptBlock
         }
     }
 
-    if ($AllowNonZero -eq $false -and $LastExitCode -ne 0) {
-        throw "Command ``$ScriptBlock`` failed with exitcode: $LastExitCode"
+    Invoke-CommandLocalOrRemote -Session $Session -ScriptBlock {
+        # If an executable in $ScriptBlock wouldn't be found then while checking $LastExitCode
+        # we would be checking the exit code of a previous command. To avoid this we clear $LastExitCode.
+        $Global:LastExitCode = $null
     }
 
+    # We need to backup only the ErrorActionPreference only in remote case,
+    # as all changes of this variable locally are scoped to a function,
+    # but when using Invoke-Comand -Session $Session, their scope is
+    # for a whole lifetime of a session.
+    if ($Session) {
+        $OldRemoteErrorAction = Invoke-Command -Session $Session { $ErrorActionPreference }
+    }
+
+    # Since we're redirecting stderr to stdout we shouldn't have to set ErrorActionPreference
+    # but because of a bug in Powershell we have to.
+    # https://github.com/PowerShell/PowerShell/issues/4002
+    if ($Session) {
+        Invoke-Command -Session $Session { $ErrorActionPreference = "Continue" }
+    }
+    $ErrorActionPreference = "Continue"
+
+    try {
+        # We redirect stderr to stdout so nothing is added to $Error.
+        # We do this to be compliant to durable-task-plugin 1.18.
+        if ($CaptureOutput) {
+            $Output = @()
+            $Output += Invoke-CommandLocalOrRemote -Session $Session -ScriptBlock $ScriptBlock 2>&1
+        } else {
+            Invoke-CommandLocalOrRemote -Session $Session -ScriptBlock $ScriptBlock 2>&1 | Write-Host
+        }
+    }
+    finally {
+        if ($Session) {
+            Invoke-Command -Session $Session { $ErrorActionPreference = $Using:OldRemoteErrorAction }
+        }
+        $ErrorActionPreference = "Stop"
+    }
+
+    $ExitCode = Invoke-CommandLocalOrRemote -Session $Session {
+        $ExitCode = $Global:LastExitCode
+        # We clear it to be compliant with durable-task-plugin up to 1.17
+        $Global:LastExitCode = $null
+        $ExitCode
+    }
+
+    if ($AllowNonZero -eq $false -and $ExitCode -ne 0) {
+        throw "Command ``$ScriptBlock`` failed with exitcode: $ExitCode"
+    }
+
+    $ReturnDict = @{}
+
     if ($AllowNonZero) {
-        $ReturnDict.ExitCode = $LastExitCode
+        $ReturnDict.ExitCode = $ExitCode
     }
 
     if ($CaptureOutput) {
         $ReturnDict.Output = $Output
     }
-
-    # We clear it to be compliant with durable-task-plugin up to 1.17
-    $Global:LastExitCode = $null
 
     return $ReturnDict
 }

--- a/CIScripts/Common/Invoke-NativeCommand.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.ps1
@@ -1,7 +1,7 @@
 function Invoke-NativeCommand {
     Param (
-        [Parameter(Mandatory = $false)] [Bool] $AllowNonZero = $false,
-        [Parameter(Mandatory = $true)] [ScriptBlock] $ScriptBlock
+        [Parameter(Mandatory = $true)] [ScriptBlock] $ScriptBlock,
+        [Switch] $AllowNonZero
     )
     # Utility wrapper.
     # We encountered issues when trying to run non-powershell commands in a script, when it's


### PR DESCRIPTION
We have this nice wrapper for executing commands locally, but nothing similar for remote commands. This is something I wished it existed a few times recently.

This PR extends the `Invoke-NativeCommand` to running in `Session`, also cleans up the parameters and makes return value a nice dictionary. This PR also adds tests for this function, which can serve as examples.