### PR TITLE
Allow connecting to a local VM in testenv

### DIFF
--- a/CIScripts/Common/VMUtils.ps1
+++ b/CIScripts/Common/VMUtils.ps1
@@ -35,7 +35,13 @@ function New-RemoteSessions {
     $Sessions = [System.Collections.ArrayList] @()
     foreach ($VM in $VMs) {
         $Creds = Get-TestbedCredential -VM $VM
-        $Sess = New-PSSession -ComputerName $VM.Address -Credential $Creds
+        $Sess = if ($VM['Address']) {
+            New-PSSession -ComputerName $VM.Address -Credential $Creds
+        } elseif ($VM['VMName']) {
+            New-PSSession -VMName $VM.VMName -Credential $Creds
+        } else {
+            throw "You need to specify 'address' or 'vmName' for a testbed."
+        }
 
         Invoke-Command -Session $Sess -ScriptBlock {
             Set-StrictMode -Version Latest


### PR DESCRIPTION
Currently, the VM is specified by address field. This address is passed as a -ComputerName to New-PSSession.

This PR adds a possibility to connect to local Hyper-V VM, by specifying vmName instead of address.
The goal of this PR is to make it easier to use `testenv-conf.yaml`for testing locally.