### PR TITLE
Don't suppress stdout and stderr in Invoke-NativeCommand

### DIFF
--- a/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.Tests.ps1
@@ -81,6 +81,11 @@ Describe "Invoke-NativeCommand" {
             Get-WriteHostOutput | Should BeNullOrEmpty
         }
 
+        It "prints the error output of a failed command" {
+            { INC -CaptureOutput { whoami.exe /invalid } } | Should Throw
+            Get-WriteHostOutput | Should Not BeNullOrEmpty
+        }
+
         It "can capture multiline output" {
             (INC -CaptureOutput { whoami.exe /? }).Output.Count | Should BeGreaterThan 1
         }

--- a/CIScripts/Common/Invoke-NativeCommand.ps1
+++ b/CIScripts/Common/Invoke-NativeCommand.ps1
@@ -89,6 +89,9 @@ function Invoke-NativeCommand {
     $Global:LastExitCode = $null
 
     if ($AllowNonZero -eq $false -and $ExitCode -ne 0) {
+        if ($CaptureOutput) {
+            $Output | Write-Host
+        }
         throw "Command ``$ScriptBlock`` failed with exitcode: $ExitCode"
     }
 


### PR DESCRIPTION
Don't suppress stdout and stderr in Invoke-NativeCommand in case of -CaptureOutput flag and non-zero exitcode of command