### PR TITLE
Print a link to published logs in logs

### DIFF
--- a/vars/publishToLogServer.groovy
+++ b/vars/publishToLogServer.groovy
@@ -1,3 +1,10 @@
+def showUrl(Map logServer, String destDir) {
+    def httpRootLocation = '/var/www/logs/'
+    if (destDir.contains(httpRootLocation)) {
+        echo ('logs published to http://' + logServer.addr + destDir.replace(httpRootLocation, '/'))
+    }
+}
+
 def call(Map logServer, String srcDir, String destDir, boolean mayThrow = true) {
     script {
         if (fileExists(srcDir)) {
@@ -5,6 +12,7 @@ def call(Map logServer, String srcDir, String destDir, boolean mayThrow = true) 
             def remoteDir = authority + ":" + destDir
             shellCommand "ssh", [authority, "mkdir", "-p", destDir]
             shellCommand "rsync", ["-r", srcDir + "/", remoteDir]
+            showUrl(logServer, destDir)
         } else {
             def message = "publishToLogServer: Directory '${src}' does not exist."
             if (mayThrow) {


### PR DESCRIPTION
When looking at the log in Jenkins, it would be nice to be able to quickly navigate to the same log on the logs server. This PR tries to do that by printing a clickable link.