### PR TITLE
Retry starting docker driver also on invalid IP

### DIFF
--- a/CIScripts/Common/Invoke-UntilSucceeds.Tests.ps1
+++ b/CIScripts/Common/Invoke-UntilSucceeds.Tests.ps1
@@ -156,7 +156,23 @@ Describe "Invoke-UntilSucceeds" {
         } -Duration 10 -Interval 5
 
         $Script:Counter | Should Be 2
-        ((Get-Date) - $StartDate).Seconds | Should Be 45
+        ((Get-Date) - $StartDate).TotalSeconds | Should Be 45
+    }
+
+    It "works with duration > 60" {
+        $Script:Counter = 0
+        $StartDate = (Get-Date)
+
+        {
+            Invoke-UntilSucceeds {
+                $Script:Counter += 1
+                $Script:Counter -eq 200
+            } -Duration 100 -Interval 1
+        } | Should Throw
+
+        $Script:Counter | Should BeGreaterThan 99
+        $Script:Counter | Should BeLessThan 200
+        ((Get-Date) - $StartDate).TotalSeconds | Should BeGreaterThan 99
     }
 
     BeforeEach {

--- a/CIScripts/Common/Invoke-UntilSucceeds.ps1
+++ b/CIScripts/Common/Invoke-UntilSucceeds.ps1
@@ -43,7 +43,7 @@ function Invoke-UntilSucceeds {
     $StartTime = Get-Date
 
     while ($true) {
-        $LastCheck = ((Get-Date) - $StartTime).Seconds -ge $Duration
+        $LastCheck = ((Get-Date) - $StartTime).TotalSeconds -ge $Duration
 
         if ($Precondition -and -not (Invoke-Command $Precondition)) {
             throw New-Object -TypeName CITimeoutException("Precondition was false, waiting aborted early")

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -346,22 +346,24 @@ function Initialize-TestConfiguration {
                 Test-IsDockerDriverEnabled -Session $Session
             } | Invoke-UntilSucceeds -Duration 600 -Interval 5 -Precondition $TestProcessRunning
 
+            $HNSTransparentAdapter = Get-RemoteNetAdapterInformation `
+                    -Session $Session `
+                    -AdapterName $SystemConfig.VHostName
+            Wait-RemoteInterfaceIP -Session $Session -ifIndex $HNSTransparentAdapter.ifIndex
+
             break
         }
         catch {
+            Write-Host $_
+
             if ($i -eq $NRetries) {
                 throw "Docker driver was not enabled."
             } else {
                 Write-Host "Docker driver was not enabled, retrying."
-                Stop-ProcessIfExists -Session $Session -ProcessName "contrail-windows-docker"
+                Clear-TestConfiguration -Session $Session -SystemConfig $SystemConfig
             }
         }
     }
-
-    $HNSTransparentAdapter = Get-RemoteNetAdapterInformation `
-            -Session $Session `
-            -AdapterName $SystemConfig.VHostName
-    Wait-RemoteInterfaceIP -Session $Session -ifIndex $HNSTransparentAdapter.ifIndex
 }
 
 function Clear-TestConfiguration {

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -304,20 +304,6 @@ function Initialize-DriverAndExtension {
         [Parameter(Mandatory = $true)] [ControllerConfig] $ControllerConfig
     )
 
-    Initialize-TestConfiguration -Session $Session `
-        -SystemConfig $SystemConfig `
-        -OpenStackConfig $OpenStackConfig `
-        -ControllerConfig $ControllerConfig
-}
-
-function Initialize-TestConfiguration {
-    Param (
-        [Parameter(Mandatory = $true)] [PSSessionT] $Session,
-        [Parameter(Mandatory = $true)] [SystemConfig] $SystemConfig,
-        [Parameter(Mandatory = $true)] [OpenStackConfig] $OpenStackConfig,
-        [Parameter(Mandatory = $true)] [ControllerConfig] $ControllerConfig
-    )
-
     Write-Host "Initializing Test Configuration"
 
     $NRetries = 3;
@@ -429,7 +415,7 @@ function Initialize-ComputeServices {
             [Parameter(Mandatory = $true)] [ControllerConfig] $ControllerConfig
         )
 
-        Initialize-TestConfiguration -Session $Session `
+        Initialize-DriverAndExtension -Session $Session `
             -SystemConfig $SystemConfig `
             -OpenStackConfig $OpenStackConfig `
             -ControllerConfig $ControllerConfig

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -88,14 +88,14 @@ function Test-IsVRouterExtensionEnabled {
     return $($Ext.Enabled -and $Ext.Running)
 }
 
-function Enable-DockerDriver {
+function Start-DockerDriver {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,
            [Parameter(Mandatory = $true)] [string] $AdapterName,
            [Parameter(Mandatory = $true)] [OpenStackConfig] $OpenStackConfig,
            [Parameter(Mandatory = $true)] [ControllerConfig] $ControllerConfig,
            [Parameter(Mandatory = $false)] [int] $WaitTime = 60)
 
-    Write-Host "Enabling Docker Driver"
+    Write-Host "Starting Docker Driver"
 
     $Arguments = @(
         "-forceAsInteractive",
@@ -139,10 +139,10 @@ function Enable-DockerDriver {
     Start-Sleep -s $WaitTime
 }
 
-function Disable-DockerDriver {
+function Stop-DockerDriver {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session)
 
-    Write-Host "Disabling Docker Driver"
+    Write-Host "Stopping Docker Driver"
 
     Stop-ProcessIfExists -Session $Session -ProcessName "contrail-windows-docker"
 
@@ -331,7 +331,7 @@ function Initialize-TestConfiguration {
     foreach ($i in 1..$NRetries) {
         # DockerDriver automatically enables Extension, so there is no need to enable it manually
 
-        Enable-DockerDriver -Session $Session `
+        Start-DockerDriver -Session $Session `
             -AdapterName $SystemConfig.AdapterName `
             -OpenStackConfig $OpenStackConfig `
             -ControllerConfig $ControllerConfig `
@@ -372,7 +372,7 @@ function Clear-TestConfiguration {
 
     Remove-AllUnusedDockerNetworks -Session $Session
     Disable-AgentService -Session $Session
-    Disable-DockerDriver -Session $Session
+    Stop-DockerDriver -Session $Session
     Disable-VRouterExtension -Session $Session -SystemConfig $SystemConfig
 }
 


### PR DESCRIPTION
This PR enables retrying on "Waiting for IP on interface time out"<sup>†</sup> error. Also, we do now print the cause of retry when retrying.

The reason for this error is probably some HNS flakiness. It should be fixed directly in Docker Driver, along with the "HNS unspecified" error. But since we're retrying in CI anyway, I see no reason why we shouldn't retry also on this error.

The actual change is in second commit – https://github.com/Juniper/contrail-windows-ci/commit/35d2e0d4f498229667973b50d21083b1860cef8d. The rest are minor bugfixes and cleanup.

 † The _time out_ is a little bit misleading here. Since we no longer have a DHCP and have manual configuration, the correct IP will never appear, no matter how long we wait. When the error occurs, the assigned IP is autoconfiguration one, instead of the same address as on Ethernet1 – eg. 172.16.0.2.