### PR TITLE
Fix merge bug between Remove-AllContainers and VMUtils.ps1 split.

### DIFF
--- a/CIScripts/Test/PesterLogger/RemoteLogCollector.Tests.ps1
+++ b/CIScripts/Test/PesterLogger/RemoteLogCollector.Tests.ps1
@@ -4,7 +4,7 @@ Param (
 )
 
 . $PSScriptRoot/../../Common/Init.ps1
-. $PSScriptRoot/../../Common/Testbed.ps1
+. $PSScriptRoot/../../Testenv/Testbed.ps1
 . $PSScriptRoot/../../Testenv/Testenv.ps1
 
 . $PSScriptRoot/Get-CurrentPesterScope.ps1

--- a/CIScripts/Test/PesterLogger/RemoteLogCollector.Tests.ps1
+++ b/CIScripts/Test/PesterLogger/RemoteLogCollector.Tests.ps1
@@ -4,7 +4,7 @@ Param (
 )
 
 . $PSScriptRoot/../../Common/Init.ps1
-. $PSScriptRoot/../../Common/VMUtils.ps1
+. $PSScriptRoot/../../Common/Testbed.ps1
 . $PSScriptRoot/../../Testenv/Testenv.ps1
 
 . $PSScriptRoot/Get-CurrentPesterScope.ps1

--- a/CIScripts/Test/RemoveAllContainers.Tests.ps1
+++ b/CIScripts/Test/RemoveAllContainers.Tests.ps1
@@ -8,6 +8,7 @@ Param (
 . $PSScriptRoot\..\Testenv\Testbed.ps1
 . $PSScriptRoot\Utils\ComponentsInstallation.ps1
 . $PSScriptRoot\Utils\ContrailUtils.ps1
+. $PSScriptRoot\..\..\PesterLogger\PesterLogger.ps1
 
 Describe "Remove-AllContainers" {
     It "Removes single container if exists" {

--- a/CIScripts/Test/RemoveAllContainers.Tests.ps1
+++ b/CIScripts/Test/RemoveAllContainers.Tests.ps1
@@ -1,20 +1,13 @@
 Param (
-    [Parameter(Mandatory=$true)] [string] $TestenvConfFile,
+    [Parameter(Mandatory=$false)] [string] $TestenvConfFile,
     [Parameter(Mandatory=$false)] [string] $LogDir = "pesterLogs"
 )
 
 . $PSScriptRoot\TestConfigurationUtils.ps1
 . $PSScriptRoot\..\Testenv\Testenv.ps1
-. $PSScriptRoot\..\Common\VMUtils.ps1
+. $PSScriptRoot\..\Testenv\Testbed.ps1
 . $PSScriptRoot\Utils\ComponentsInstallation.ps1
 . $PSScriptRoot\Utils\ContrailUtils.ps1
-
-$Sessions = New-RemoteSessions -VMs (Read-TestbedsConfig -Path $TestenvConfFile)
-$Session = $Sessions[0]
-
-$OpenStackConfig = Read-OpenStackConfig -Path $TestenvConfFile
-$ControllerConfig = Read-ControllerConfig -Path $TestenvConfFile
-$SystemConfig = Read-SystemConfig -Path $TestenvConfFile
 
 Describe "Remove-AllContainers" {
     It "Removes single container if exists" {
@@ -92,6 +85,19 @@ Describe "Remove-AllContainers" {
     }
 
     BeforeAll {
+        $Sessions = New-RemoteSessions -VMs (Read-TestbedsConfig -Path $TestenvConfFile)
+        $Session = $Sessions[0]
+
+        $OpenStackConfig = Read-OpenStackConfig -Path $TestenvConfFile
+        $ControllerConfig = Read-ControllerConfig -Path $TestenvConfFile
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+            "PSUseDeclaredVarsMoreThanAssignments", "",
+            Justification="Analyzer doesn't understand relation of Pester blocks"
+        )]
+        $SystemConfig = Read-SystemConfig -Path $TestenvConfFile
+
+        Initialize-PesterLogger -OutDir $LogDir
+
         Install-DockerDriver -Session $Session
         Install-Extension -Session $Session
 
@@ -104,9 +110,9 @@ Describe "Remove-AllContainers" {
     }
 
     AfterAll {
+        if (-not (Get-Variable Sessions -ErrorAction SilentlyContinue)) { return }
         Uninstall-DockerDriver -Session $Session
         Uninstall-Extension -Session $Session
+        Remove-PSSession $Sessions
     }
-
 }
-Remove-PSSession $Sessions

--- a/CIScripts/Test/RemoveAllContainers.Tests.ps1
+++ b/CIScripts/Test/RemoveAllContainers.Tests.ps1
@@ -8,7 +8,7 @@ Param (
 . $PSScriptRoot\..\Testenv\Testbed.ps1
 . $PSScriptRoot\Utils\ComponentsInstallation.ps1
 . $PSScriptRoot\Utils\ContrailUtils.ps1
-. $PSScriptRoot\..\..\PesterLogger\PesterLogger.ps1
+. $PSScriptRoot\PesterLogger\PesterLogger.ps1
 
 Describe "Remove-AllContainers" {
     It "Removes single container if exists" {

--- a/CIScripts/Test/Tests/Protocol/TunnellingWithAgent.Tests.ps1
+++ b/CIScripts/Test/Tests/Protocol/TunnellingWithAgent.Tests.ps1
@@ -9,7 +9,7 @@ Param (
 . $PSScriptRoot\..\..\Utils\ContrailNetworkManager.ps1
 . $PSScriptRoot\..\..\TestConfigurationUtils.ps1
 . $PSScriptRoot\..\..\..\Testenv\Testenv.ps1
-. $PSScriptRoot\..\..\..\Common\VMUtils.ps1
+. $PSScriptRoot\..\..\..\Testenv\Testbed.ps1
 . $PSScriptRoot\..\..\PesterHelpers\PesterHelpers.ps1
 . $PSScriptRoot\..\..\Utils\CommonTestCode.ps1
 . $PSScriptRoot\..\..\Utils\DockerImageBuild.ps1


### PR DESCRIPTION
Fixes merge bug between https://github.com/Juniper/contrail-windows-ci/pull/90 and https://github.com/Juniper/contrail-windows-ci/pull/101

```
    CommandNotFoundException: The term 'J:\Jenkins\workspace\WinContrail\contrail-docker-driver-gh-devel\CIScripts\Test\Tests\Protocol\..\..\..\Common\VMUtils.ps1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```