### PR TITLE
fix: Change datacenter/cluster/validate_certs variable names

### DIFF
--- a/ansible/roles/vmware-template/tasks/create.yml
+++ b/ansible/roles/vmware-template/tasks/create.yml
@@ -11,10 +11,10 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
 
-    datacenter: "{{ datacenter_name }}"
-    cluster: "{{ cluster_name }}"
+    datacenter: "{{ vcenter_datacenter }}"
+    cluster: "{{ vcenter_cluster }}"
     folder: "{{ vmware_folder }}"
 
     name: "{{ template_name }}"
@@ -47,11 +47,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
 
-    datacenter: "{{ datacenter_name }}"
-    cluster: "{{ cluster_name }}"
-    folder: "{{ datacenter_name }}/vm/{{ vmware_folder }}"
+    datacenter: "{{ vcenter_datacenter }}"
+    cluster: "{{ vcenter_cluster }}"
+    folder: "{{ vcenter_datacenter }}/vm/{{ vmware_folder }}"
     name: "{{ template_name }}"
     state: rebootguest
 
@@ -63,9 +63,9 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
 
-    datacenter: "{{ datacenter_name }}"
+    datacenter: "{{ vcenter_datacenter }}"
 
     uuid: "{{ new_vm.instance.hw_product_uuid }}"
   retries: 60

--- a/ansible/roles/vmware-template/tasks/deploy.yml
+++ b/ansible/roles/vmware-template/tasks/deploy.yml
@@ -16,10 +16,10 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
 
-    datacenter: "{{ datacenter_name }}"
-    cluster: "{{ cluster_name }}"
+    datacenter: "{{ vcenter_datacenter }}"
+    cluster: "{{ vcenter_cluster }}"
     folder: "{{ vmware_folder }}"
 
     name: "winci-{{ vm_role}}-{{ get_vm_id.stdout.strip() }}"
@@ -41,9 +41,9 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
 
-    datacenter: "{{ datacenter_name }}"
+    datacenter: "{{ vcenter_datacenter }}"
 
     uuid: "{{ new_vm.instance.hw_product_uuid }}"
   retries: 60

--- a/ansible/roles/vmware-template/tasks/shutdown.yml
+++ b/ansible/roles/vmware-template/tasks/shutdown.yml
@@ -5,7 +5,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
     name: "{{ new_vm.instance.hw_name }}"
     uuid: "{{ new_vm.instance.hw_product_uuid }}"
     state: shutdownguest
@@ -16,9 +16,9 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
 
-    datacenter: "{{ datacenter_name }}"
+    datacenter: "{{ vcenter_datacenter }}"
 
     uuid: "{{ new_vm.instance.hw_product_uuid }}"
   retries: 60

--- a/ansible/roles/vmware-template/tasks/snapshot.yml
+++ b/ansible/roles/vmware-template/tasks/snapshot.yml
@@ -9,9 +9,9 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_user }}"
     password: "{{ vcenter_password }}"
-    validate_certs: "{{ validate_certs }}"
-    datacenter: "{{ datacenter_name }}"
-    folder: "{{ datacenter_name }}/vm/{{ vmware_folder }}"
+    validate_certs: "{{ vcenter_validate_certs }}"
+    datacenter: "{{ vcenter_datacenter }}"
+    folder: "{{ vcenter_datacenter }}/vm/{{ vmware_folder }}"
     name: "{{ new_vm.instance.hw_name }}"
     state: present
     snapshot_name: linked-clones-base # TODO: Move it to vars


### PR DESCRIPTION
Required by changes in `group_vars/all/vault`

- `datacenter_name` is now `vcenter_datacenter`
- `cluster_name` is now `vcenter_cluster`
- `validate_certs` is now `vcenter_validate_certs`