### PR TITLE
Move AGENT_BUILD_THREADS env to jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
                         THIRD_PARTY_CACHE_PATH = "C:/BUILD_DEPENDENCIES/third_party_cache/"
                         DRIVER_SRC_PATH = "github.com/Juniper/contrail-windows-docker-driver"
                         BUILD_IN_RELEASE_MODE = "false"
+                        AGENT_BUILD_THREADS = "6"
                         SIGNTOOL_PATH = "C:/Program Files (x86)/Windows Kits/10/bin/x64/signtool.exe"
                         CERT_PATH = "C:/BUILD_DEPENDENCIES/third_party_cache/common/certs/codilime.com-selfsigned-cert.pfx"
                         CERT_PASSWORD_FILE_PATH = "C:/BUILD_DEPENDENCIES/third_party_cache/common/certs/certp.txt"


### PR DESCRIPTION
AGENT_BUILD_THREADS can be moved to jenkinsfile, since we are using the
same configuration for development and production pipelines.