### PR TITLE
Removed symlinking boost and MSBUILD variable

### DIFF
--- a/CIScripts/Build/BuildFunctions.ps1
+++ b/CIScripts/Build/BuildFunctions.ps1
@@ -12,10 +12,6 @@ function Initialize-BuildEnvironment {
             Copy-Item -Destination third_party\ -Recurse -Force
     })
 
-    $Job.Step("Symlinking boost", {
-        New-Item -Path "third_party\boost_1_62_0" -ItemType SymbolicLink -Value "$ThirdPartyCache\boost_1_62_0" | Out-Null
-    })
-
     $Job.Step("Copying SConstruct from tools\build", {
         Copy-Item tools\build\SConstruct .
     })

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,6 @@ pipeline {
                         CERT_PASSWORD_FILE_PATH = "C:/BUILD_DEPENDENCIES/third_party_cache/common/certs/certp.txt"
                         COMPONENTS_TO_BUILD = "DockerDriver,Extension,Agent"
 
-                        MSBUILD = "C:/Program Files (x86)/MSBuild/14.0/Bin/MSBuild.exe"
                         WINCIDEV = credentials('winci-drive')
                     }
                     steps {


### PR DESCRIPTION
During a build we use boost which is already installed on builder
MSBUILD variable is already set on builders