### PR TITLE
Use ginkgo succinct flag to make test output very minimal.

### DIFF
--- a/CIScripts/Test/Tests/Integration/DockerDriver.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/DockerDriver.Tests.ps1
@@ -19,7 +19,7 @@ function Invoke-DockerDriverUnitTest {
     )
 
     $TestFilePath = ".\" + $Component + ".test.exe"
-    $Command = @($TestFilePath, "--ginkgo.noisyPendings", "--ginkgo.failFast", "--ginkgo.progress", "--ginkgo.v", "--ginkgo.trace")
+    $Command = @($TestFilePath, "--ginkgo.succinct", "--ginkgo.failFast")
     $Command = $Command -join " "
 
     $Res = Invoke-NativeCommand -CaptureOutput -AllowNonZero -Session $Session {


### PR DESCRIPTION
Reasoning: 
1. we want to use report generator anyways
2. logs are cluttered

Old: http://logs.opencontrail.org/winci/github/WinContrail/contrail-win-ci-gh/1514/detailed_logs/Docker%20Driver.Tests%20for%20module%20agent.Tests%20are%20invoked.log

New: http://logs.opencontrail.org/winci/github/WinContrail/contrail-win-ci-gh/1535/detailed_logs/Docker%20Driver.Tests%20for%20module%20agent.Tests%20are%20invoked.log