### PR TITLE
Updated contrail-ansible-deployer

### DIFF
--- a/ansible/roles/controller/defaults/main.yml
+++ b/ansible/roles/controller/defaults/main.yml
@@ -1,7 +1,7 @@
 docker_registry: "ci-repo.englab.juniper.net:5000"
-contrail_version: "ocata-master-63"
+contrail_version: "ocata-master-91"
 kolla_version: "ocata"
-contrail_ansible_deployer_version: "c46fb61bd4b355e96bd5eb0ba735996e2e53d5dc"
+contrail_ansible_deployer_version: "6b86bcd7056e20c6d36d3808d2750b1395528b11"
 docker_bridge_network: "172.26.0.1/16"
 site_pulp:
   fqdn: ci-repo.englab.juniper.net


### PR DESCRIPTION
Update is required because 'centos-openstack-release-ocata' package is not needed