### PR TITLE
Remove pkg-resources from requirements.txt

### DIFF
--- a/ansible/python-requirements.txt
+++ b/ansible/python-requirements.txt
@@ -12,7 +12,6 @@ MarkupSafe==1.0
 netaddr==0.7.19
 ntlm-auth==1.0.6
 paramiko==2.3.1
-pkg-resources==0.0.0
 pyasn1==0.3.7
 pycparser==2.18
 PyNaCl==1.1.2


### PR DESCRIPTION
`pkg-resources==0.0.0` was generated by `pip freeze` because of bug in `pip` package definition on Ubuntu (https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463).