### PR TITLE
Fix driver junit report discovery. Refactors.

### DIFF
--- a/CIScripts/Test/TestRunner.ps1
+++ b/CIScripts/Test/TestRunner.ps1
@@ -10,9 +10,13 @@ function Invoke-TestScenarios {
     )
 
     $DetailedLogDir = Join-Path $TestReportOutputDirectory "detailed"
+    $AdditionalJUnitsDir = Join-Path $TestReportOutputDirectory "junit"
+    # TODO: Maybe we should collect codecov statistics similarly in the future?
+
     $AdditionalParams = @{
         TestenvConfFile=$TestenvConfFile;
         LogDir=$DetailedLogDir;
+        AdditionalJUnitsDir=$AdditionalJUnitsDir;
     }
     $Results = Invoke-PesterTests -TestRootDir $pwd -ReportDir $TestReportOutputDirectory `
         -ExcludeTags CI -AdditionalParams $AdditionalParams

--- a/CIScripts/Test/Tests/Integration/DockerDriver.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/DockerDriver.Tests.ps1
@@ -1,6 +1,7 @@
 Param (
     [Parameter(Mandatory=$false)] [string] $TestenvConfFile,
-    [Parameter(Mandatory=$false)] [string] $LogDir = "pesterLogs"
+    [Parameter(Mandatory=$false)] [string] $LogDir = "pesterLogs",
+    [Parameter(Mandatory=$false)] [string] $AdditionalJUnitsDir = "AdditionalJUnitLogs"
 )
 
 . $PSScriptRoot\..\..\..\Common\Aliases.ps1
@@ -10,15 +11,16 @@ Param (
 . $PSScriptRoot\..\..\PesterLogger\PesterLogger.ps1
 . $PSScriptRoot\..\..\PesterLogger\RemoteLogCollector.ps1
 
-$TestsPath = "C:\Artifacts\"
+# TODO: This path should probably come from TestenvConfFile.
+$RemoteTestModulesDir = "C:\Artifacts\"
 
 function Find-DockerDriverTests {
     Param (
         [Parameter(Mandatory=$true)] [PSSessionT] $Session,
-        [Parameter(Mandatory=$true)] [string] $RootTestModulePath
+        [Parameter(Mandatory=$true)] [string] $RemoteSearchDir
     )
     $TestModules = Invoke-Command -Session $Session {
-        Get-ChildItem -Recurse -Filter "*.test.exe" -Path $Using:RootTestModulePath `
+        Get-ChildItem -Recurse -Filter "*.test.exe" -Path $Using:RemoteSearchDir `
             | Select-Object BaseName, FullName
     }
     Write-Log "Discovered test modules: $($TestModules.BaseName)"
@@ -28,14 +30,15 @@ function Find-DockerDriverTests {
 function Invoke-DockerDriverUnitTest {
     Param (
         [Parameter(Mandatory=$true)] [PSSessionT] $Session,
-        [Parameter(Mandatory=$true)] [string] $TestModulePath
+        [Parameter(Mandatory=$true)] [string] $TestModulePath,
+        [Parameter(Mandatory=$true)] [string] $RemoteJUnitOutputDir
     )
 
     $Command = @($TestModulePath, "--ginkgo.succinct", "--ginkgo.failFast")
     $Command = $Command -join " "
 
     $Res = Invoke-NativeCommand -CaptureOutput -AllowNonZero -Session $Session {
-        Push-Location $Using:TestsPath
+        Push-Location $Using:RemoteJUnitOutputDir
         try {
             Invoke-Expression -Command $Using:Command
         } finally {
@@ -51,12 +54,19 @@ function Invoke-DockerDriverUnitTest {
 function Save-DockerDriverUnitTestReport {
     Param (
         [Parameter(Mandatory=$true)] [PSSessionT] $Session,
-        [Parameter(Mandatory=$true)] [string] $TestModulePath
+        [Parameter(Mandatory=$true)] [String] $RemoteJUnitDir,
+        [Parameter(Mandatory=$true)] [string] $LocalJUnitDir
     )
 
-    # TODO Where are these files copied to?
-    # TODO2: Fix JUnit reporters first....
-    # Copy-Item -FromSession $Session -Path ($TestsPath + $TestModulePath + "_junit.xml") -ErrorAction SilentlyContinue
+    if (-not (Test-Path $LocalJUnitDir)) {
+        New-Item -ItemType Directory -Path $LocalJUnitDir | Out-Null
+    }
+
+    $FoundRemoteJUnitReports = Invoke-Command -FromSession $Session -ScriptBlock { 
+        Get-ChildItem -Filter "*_junit.xml" -Recurse -Path $Using:RemoteJUnitDir
+    }
+
+    Copy-Item $FoundRemoteJUnitReports.FullName -Destination $LocalJUnitDir -FromSession $Session
 }
 
 Describe "Docker Driver" {
@@ -70,7 +80,7 @@ Describe "Docker Driver" {
             "PSUseDeclaredVarsMoreThanAssignments", "",
             Justification="Analyzer doesn't understand relation of Pester blocks"
         )]
-        $FoundTestModules = Find-DockerDriverTests -RootTestModulePath "C:\Artifacts\" -Session $Session
+        $FoundTestModules = Find-DockerDriverTests -RemoteSearchDir $RemoteTestModulesDir -Session $Session
     }
 
     AfterAll {
@@ -81,12 +91,12 @@ Describe "Docker Driver" {
     foreach ($TestModule in $FoundTestModules) {
         Context "Tests for module in $($TestModule.BaseName)" {
             It "passes tests" {
-                $TestResult = Invoke-DockerDriverUnitTest -Session $Session -TestModulePath $TestModule.FullName
+                $TestResult = Invoke-DockerDriverUnitTest -Session $Session -TestModulePath $TestModule.FullName -RemoteJUnitOutputDir $RemoteTestModulesDir
                 $TestResult | Should Be 0
             }
 
             AfterEach {
-                Save-DockerDriverUnitTestReport -Session $Session -TestModulePath $TestModule.FullName
+                Save-DockerDriverUnitTestReport -Session $Session -RemoteJUnitDir $RemoteTestModulesDir -LocalJUnitDir $AdditionalJUnitsDir
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,6 +198,7 @@ pipeline {
                         dir('test_report/detailed') {
                             stash name: 'detailedLogs', allowEmpty: true
                         }
+                        stash name: 'testReportsGo', includes: 'test_report/junit', allowEmpty: true
                     }
                 }
             }
@@ -246,7 +247,8 @@ pipeline {
 
                     dir('to_publish') {
                         unstash 'processedTestReport'
-
+                        unstash 'testReportsGo'
+                        
                         dir('detailed_logs') {
                             try {
                                 unstash 'detailedLogs'


### PR DESCRIPTION
Collect docker driver unit tests xml junit reports from testbed machines. Move them to a temporary reports location for now (to avoid any problems with html report generation). Some slight refactors along the way.