### PR TITLE
Add openshift-ansible repo. Sort project names automatically.

### DIFF
--- a/ansible/roles/zuul/files/layout.yaml
+++ b/ansible/roles/zuul/files/layout.yaml
@@ -294,6 +294,10 @@ projects:
     template:
       - name: ci-contrail-windows-other-projects-template
 
+  - name: Juniper/openshift-ansible
+    template:
+      - name: ci-contrail-windows-other-projects-template
+
   - name: Juniper/openstack-helm
     template:
       - name: ci-contrail-windows-other-projects-template

--- a/ansible/update-zuul-layout.py
+++ b/ansible/update-zuul-layout.py
@@ -66,7 +66,7 @@ with open(layout_file, "w", newline="\n") as new_layout_file:
     for line in lines_to_preserve:
         print(line, file=new_layout_file)
 
-    for project_name, _ in projects.items():
+    for project_name, _ in sorted(projects.items()):
         if not project_name in actually_used_projects \
                 and relevant_project_name_re.match(project_name):
             print(template.format(project_name), file=new_layout_file)


### PR DESCRIPTION
Adding openshift-ansible repo to layout.

Project names will now be sorted alphabetically because otherwise the diff is unreadable.

Relevant: https://github.com/Juniper/contrail-windows-ci/pull/157