### PR TITLE
Handle tungstenfabric and Juniper organizations on gerrit.

### DIFF
--- a/ansible/roles/zuul/files/layout.yaml
+++ b/ansible/roles/zuul/files/layout.yaml
@@ -317,3 +317,7 @@ projects:
   - name: Juniper/vijava
     template:
       - name: ci-contrail-windows-other-projects-template
+
+  - name: tungstenfabric/contrail-ci-test
+    template:
+      - name: ci-contrail-windows-other-projects-template

--- a/ansible/update-zuul-layout.py
+++ b/ansible/update-zuul-layout.py
@@ -30,7 +30,7 @@ actually_used_projects = [
 
 projects = []
 lines_to_preserve = []
-relevant_project_name_re = re.compile("Juniper/.*")
+relevant_project_name_re = re.compile("(Juniper|tungstenfabric)/.*")
 
 print("> Reading original layout file...")
 


### PR DESCRIPTION
As per @vmahuli's request. We need to be able to handle tungstenfabric organization on gerrit.