### PR TITLE
Fix encoding of index.html in python Dockerfile

### DIFF
--- a/CIScripts/DockerFiles/python-http/Dockerfile
+++ b/CIScripts/DockerFiles/python-http/Dockerfile
@@ -3,5 +3,5 @@ FROM python:3.6.5
 EXPOSE 8080
 
 WORKDIR C:/
-RUN echo "Hello, Contrail!" > index.html
+RUN ["cmd", "/A", "/C", "echo Hello, Contrail! > index.html"]
 ENTRYPOINT python -m http.server 8080


### PR DESCRIPTION
For some reason, default RUN behaves as if the `/U` parameter
was passed to cmd, which resulted in UTF-16 encoded files.

We pass the `/A` (ansi) flag explicitely.