### PR TITLE
Comment on ANSI encoding in Python dockerfile.

### DIFF
--- a/CIScripts/DockerFiles/python-http/Dockerfile
+++ b/CIScripts/DockerFiles/python-http/Dockerfile
@@ -3,5 +3,9 @@ FROM python:3.6.5
 EXPOSE 8080
 
 WORKDIR C:/
+
+# By default, RUN behaves as if the /U parameter was passed to cmd.
+# This results in UTF-16 encoded files.
+# To prevent this, /A (ansi) flag is passed explicitely.
 RUN ["cmd", "/A", "/C", "echo Hello, Contrail! > index.html"]
 ENTRYPOINT python -m http.server 8080


### PR DESCRIPTION
Adds description of change introduced in https://github.com/Juniper/contrail-windows-ci/pull/167 