### PR TITLE
[WIP] Stop trusting Docker Driver on logging to a file

### DIFF
--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -129,6 +129,7 @@ function Start-DockerDriver {
 
         Start-Job -ScriptBlock {
             Param($Arguments, $LogPath)
+            $ErrorActionPreference = "Continue"
             & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" $Arguments 2>> $LogPath
         } -ArgumentList $Arguments, $LogPath
     }

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -135,7 +135,7 @@ function Start-DockerDriver {
             $ErrorActionPreference = "Continue"
 
             & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" $Arguments 2>&1 |
-                Out-File -Append -Width 4096 $LogPath
+                Add-Content -NoNewline $LogPath
         } -ArgumentList $Arguments, $LogDir
     }
 

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -134,7 +134,8 @@ function Start-DockerDriver {
             $LogPath = Join-Path $LogDir "contrail-windows-docker-driver.log"
             $ErrorActionPreference = "Continue"
 
-            & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" $Arguments 2>> $LogPath
+            & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" $Arguments 2>&1 |
+                Out-File -Append -Width 4096 $LogPath
         } -ArgumentList $Arguments, $LogDir
     }
 

--- a/CIScripts/Test/TestConfigurationUtils.ps1
+++ b/CIScripts/Test/TestConfigurationUtils.ps1
@@ -106,7 +106,7 @@ function Start-DockerDriver {
     # TODO: Remove this when after "no log file" option is supported.
     $OldLogPath = "NUL"
 
-    $LogPath = Join-Path (Get-ComputeLogsDir) "contrail-windows-docker-driver.log"
+    $LogDir = Get-ComputeLogsDir
 
     $Arguments = @(
         "-forceAsInteractive",
@@ -125,13 +125,17 @@ function Start-DockerDriver {
 
         # Nested ScriptBlock variable passing workaround
         $Arguments = $Using:Arguments
-        $LogPath = $Using:LogPath
+        $LogDir = $Using:LogDir
 
         Start-Job -ScriptBlock {
-            Param($Arguments, $LogPath)
+            Param($Arguments, $LogDir)
+
+            New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+            $LogPath = Join-Path $LogDir "contrail-windows-docker-driver.log"
             $ErrorActionPreference = "Continue"
+
             & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" $Arguments 2>> $LogPath
-        } -ArgumentList $Arguments, $LogPath
+        } -ArgumentList $Arguments, $LogDir
     }
 
     Start-Sleep -s $WaitTime

--- a/CIScripts/Testenv/Testbed.ps1
+++ b/CIScripts/Testenv/Testbed.ps1
@@ -46,4 +46,6 @@ function New-RemoteSessions {
     return $Sessions
 }
 
-function Get-ComputeLogsPath { "C:/ProgramData/Contrail/var/log/contrail/*.log" }
+function Get-ComputeLogsDir { "C:/ProgramData/Contrail/var/log/contrail" }
+
+function Get-ComputeLogsPath { Join-Path (Get-ComputeLogsDir) "*.log" }


### PR DESCRIPTION
We'd like to capture information about panics and crashes
in the Docker Driver. It seems to be easier to do it by
just capturing the whole stderr outside the Docker Driver
rather than manually setting up hooks in the logging library.