### PR TITLE
Ensure robocopy is only ran when there is something to copy.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,7 +258,10 @@ pipeline {
 
                         // Using robocopy to workaround 260 chars path length limitation in Copy-Item.
                         // TODO: Similar method may be used when CISelfcheck generates detailed logs.
-                        robocopy("${pwd()}/testReportsRaw/WindowsCompute/detailed/", "${pwd()}/TestReports/WindowsCompute/detailedLogs", "*.log")
+                        def src = "${pwd()}/testReportsRaw/WindowsCompute/detailed/"
+                        if (fileExists(src)) {
+                            robocopy(src, "${pwd()}/TestReports/WindowsCompute/detailedLogs", "*.log")
+                        }
 
                         stash name: 'processedTestReports', includes: 'TestReports/**', allowEmpty: true
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,9 +258,9 @@ pipeline {
 
                         // Using robocopy to workaround 260 chars path length limitation in Copy-Item.
                         // TODO: Similar method may be used when CISelfcheck generates detailed logs.
-                        def src = "${pwd()}/testReportsRaw/WindowsCompute/detailed/"
-                        if (fileExists(src)) {
-                            robocopy(src, "${pwd()}/TestReports/WindowsCompute/detailedLogs", "*.log")
+                        def detailedLogsDir = "${pwd()}/testReportsRaw/WindowsCompute/detailed/"
+                        if (fileExists(detailedLogsDir)) {
+                            robocopy(detailedLogsDir, "${pwd()}/TestReports/WindowsCompute/detailedLogs", "*.log")
                         }
 
                         stash name: 'processedTestReports', includes: 'TestReports/**', allowEmpty: true


### PR DESCRIPTION
Fixes bug, where post stage would fail when before publishing logs:

e.g. here:
https://review.opencontrail.org/#/c/43493/
http://logs.opencontrail.org/winci/0e0e791838484d79bbc9208c55bd7ef1/

This is because robocopy would not copy anything (so robocopy exit code = 0) - but we would throw (because we only care about exit code = 1).

For now, this is a temporary fix using fileExists, because Arkadiusz is refactoring the stashes in that stage atm. 
- [x] Test using https://github.com/Juniper/contrail-windows-docs/blob/master/doc/ci_admin_guide/Run_gerrit_pipeline_on_github_PR.md -
 http://10.84.12.26:8080/job/WinContrail/view/PrivateJobs/job/winci-server2016-devel-gerrit-check/2/console