### PR TITLE
Enable strict mode everywhere

### DIFF
--- a/CIScripts/Checkout.ps1
+++ b/CIScripts/Checkout.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot\Common\Init.ps1
 . $PSScriptRoot\Common\Job.ps1
 . $PSScriptRoot\Checkout\Zuul.ps1
 . $PSScriptRoot\Checkout\NonZuul.ps1

--- a/CIScripts/Common/Invoke-CommandInLocation.Tests.ps1
+++ b/CIScripts/Common/Invoke-CommandInLocation.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot\Init.ps1
 . $PSScriptRoot/Invoke-CommandInLocation.ps1
 
 Describe "Invoke-CommandInLocation" -Tags CI, Unit {

--- a/CIScripts/Test/PesterLogger/Get-CurrentPesterScope.Tests.ps1
+++ b/CIScripts/Test/PesterLogger/Get-CurrentPesterScope.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\Common\Init.ps1
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"

--- a/CIScripts/Test/PesterLogger/PesterLogger.Tests.ps1
+++ b/CIScripts/Test/PesterLogger/PesterLogger.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\Common\Init.ps1
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"

--- a/CIScripts/Test/Tests/Integration/AgentRegistering.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/AgentRegistering.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Agent registering" {
     Context "Compute node" {
         It "appears in DnsAgentList" -Pending {

--- a/CIScripts/Test/Tests/Integration/DockerDriverNetworking.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/DockerDriverNetworking.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Docker driver networking" {
     Context "conflicting local IPs" {
         It "can create containers for different tenants with same IP" -Pending {

--- a/CIScripts/Test/Tests/Integration/Flows.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/Flows.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Flows" {
     It "injects flows on ICMP traffic" -Pending {
         # Test-FlowsAreInjectedOnIcmpTraffic

--- a/CIScripts/Test/Tests/Integration/ForwardingExtension.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/ForwardingExtension.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Forwarding extension" {
     It "enabling/disabling multiple consecutive times doesn't crash the system" -Pending {
         # Test-MultiEnableDisableExtension

--- a/CIScripts/Test/Tests/Integration/Pkt0.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/Pkt0.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "pkt0 interface" {
     It "pkt0 appears in vRouter when agent is started" -Pending {
         # Test-InitialPkt0Injection

--- a/CIScripts/Test/Tests/Integration/SNAT.Tests.ps1
+++ b/CIScripts/Test/Tests/Integration/SNAT.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "SNAT manual setup" {
     It "cleans up VMA" -Pending {
         # Test-VMAShouldBeCleanedUp

--- a/CIScripts/Test/Tests/Protocol/TunnelingWithUtils.Tests.ps1
+++ b/CIScripts/Test/Tests/Protocol/TunnelingWithUtils.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Tunnelling with utils tests" {
     Context "MPLSoGRE" {
         It "ICMP" -Pending {

--- a/CIScripts/Test/Tests/Protocol/WindowsLinuxInterop.Tests.ps1
+++ b/CIScripts/Test/Tests/Protocol/WindowsLinuxInterop.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Windows Linux interoperation tests" {
     It "ICMP connectivity works" -Pending {
         # Test-IcmpLinuxWindowsConnectivity

--- a/CIScripts/Test/Tests/Reliability/ForwardingExtLongLeak.Tests.ps1
+++ b/CIScripts/Test/Tests/Reliability/ForwardingExtLongLeak.Tests.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\..\..\..\Common\Init.ps1
+
 Describe "Forwarding extension long leak test" {
     It "doesn't crash the system when idle for a long time" -Pending {
         # Test-ExtensionLongLeak

--- a/CIScripts/Test/Utils/RegisterDefaultResorces.ps1
+++ b/CIScripts/Test/Utils/RegisterDefaultResorces.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot\..\..\Common\Init.ps1
 . $PSScriptRoot/ContrailUtils.ps1
 
 function Register-DefaultResourcesInContrail {

--- a/CIScripts/Testenv/Testenv.Tests.ps1
+++ b/CIScripts/Testenv/Testenv.Tests.ps1
@@ -1,3 +1,4 @@
+. $PSScriptRoot\..\Common\Init.ps1
 . $PSScriptRoot\Testenv.ps1
 
 Describe "Testenv" {

--- a/Invoke-Selfcheck.ps1
+++ b/Invoke-Selfcheck.ps1
@@ -5,6 +5,7 @@ Param (
     [switch] $SkipStaticAnalysis
 )
 
+. $PSScriptRoot\CIScripts\Common\Init.ps1
 . $PSScriptRoot/CIScripts/TestRunner/Invoke-PesterTests.ps1
 
 # NOTE TO DEVELOPERS

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -1,6 +1,9 @@
 Param([Parameter(Mandatory = $true)] [string] $RootDir,
       [Parameter(Mandatory = $true)] [string] $ConfigDir)
 
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
 $PSLinterConfig = "$ConfigDir/PSScriptAnalyzerSettings.psd1"
 Write-Host "Running PSScriptAnalyzer... (config from $PSLinterConfig)"
 


### PR DESCRIPTION
To enable strict mode, we've usually been using `Init.ps1` (which enables strict mode and sets error action). This PR adds this import in all root scripts and tests.

The exception is the `StaticAnalysis/Invoke-StaticAnalysisTools.ps1`—I've decided to set the strict mode explicitely, to keep it independent of `CIScripts`.

I thought that we were already using strict mode everywhere, but adding a warning for missing strict mode in [**shelly**](https://github.com/krdln/shelly) had proved me wrong.