### PR TITLE
Rename ScontsTestsLogs to vRouterUnitTestReport

### DIFF
--- a/CIScripts/Build.ps1
+++ b/CIScripts/Build.ps1
@@ -19,7 +19,7 @@ $vtestOutputDir = "output/vtest"
 $AgentOutputDir = "output/agent"
 $DllsOutputDir = "output/dlls"
 $LogsDir = "logs"
-$SconsTestsLogsDir = "SconsTestsLogs"
+$vRouterUnitTestReportDir = "vRouterUnitTestReport"
 
 $Directories = @(
     $DockerDriverOutputDir,
@@ -28,7 +28,7 @@ $Directories = @(
     $AgentOutputDir,
     $DllsOutputDir,
     $LogsDir,
-    $SconsTestsLogsDir
+    $vRouterUnitTestReportDir
 )
 
 foreach ($Directory in $Directories) {
@@ -80,7 +80,7 @@ try {
         Copy-DebugDlls -OutputPath $DllsOutputDir
     }
 } finally {
-    Copy-Item -Path ".\build\$BuildMode" -Destination $SconsTestsLogsDir `
+    Copy-Item -Path ".\build\$BuildMode" -Destination $vRouterUnitTestReportDir `
         -Recurse -Filter "*.exe.log" -Container
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
                     }
                     post {
                         always {
-                            stash name: "sconsTestsLogs", allowEmpty: true, includes: "SconsTestsLogs/**"
+                            stash name: "vRouterUnitTests", allowEmpty: true, includes: "vRouterUnitTestReport/**"
                             deleteDir()
                         }
                     }
@@ -286,7 +286,7 @@ pipeline {
                         dir('TestReports') {
                             tryUnstash('ddriverJUnitLogs')
                             tryUnstash('detailedLogs')
-                            tryUnstash('sconsTestsLogs')
+                            tryUnstash('vRouterUnitTests')
                         }
 
                         createCompressedLogFile(env.JOB_NAME, env.BUILD_NUMBER, logFilename)


### PR DESCRIPTION
I feel like the old name is not descriptive enough for folks outside of Windows team.