### PR TITLE
Bump paramiko version to 2.3.2 due to CVE

### DIFF
--- a/ansible/python-requirements.txt
+++ b/ansible/python-requirements.txt
@@ -11,7 +11,7 @@ Jinja2==2.10
 MarkupSafe==1.0
 netaddr==0.7.19
 ntlm-auth==1.0.6
-paramiko==2.3.1
+paramiko==2.3.2
 pyasn1==0.3.7
 pycparser==2.18
 PyNaCl==1.1.2


### PR DESCRIPTION
GitHub reported that currently frozen paramiko version is vulnerable to
https://nvd.nist.gov/vuln/detail/CVE-2018-7750
This PR bumps paramiko to first major version which is not vulnerable