### PR TITLE
Silence the output of ReportUnit.exe

### DIFF
--- a/CIScripts/Report/GenerateTestReport.ps1
+++ b/CIScripts/Report/GenerateTestReport.ps1
@@ -30,9 +30,9 @@ function Convert-TestReportsToHtml {
 
 function Invoke-RealReportunit {
     param([Parameter(Mandatory = $true)] [string] $NUnitDir)
-    Invoke-NativeCommand -ScriptBlock {
+    Invoke-NativeCommand -CaptureOutput -ScriptBlock {
         ReportUnit.exe $NUnitDir
-    }
+    } | Out-Null
 }
 
 function New-FixedTestReports {


### PR DESCRIPTION
To make our logs more readable