### PR TITLE
Throw when container gets an autoconfiguration IP

### DIFF
--- a/Test/Utils/CommonTestCode.ps1
+++ b/Test/Utils/CommonTestCode.ps1
@@ -88,6 +88,10 @@ function Assert-IsIpAddressInRawNetAdapterInfoValid {
     if (!$RawAdapterInfo.IPAddress -or ($RawAdapterInfo.IPAddress -isnot [string])) {
         throw "Invalid IPAddress returned from container: $($RawAdapterInfo.IPAddress | ConvertTo-Json)"
     }
+
+    if ($RawAdapterInfo.IPAddress -Match '^169\.254') {
+        throw "Container reports an autoconfiguration IP address: $( $RawAdapterInfo.IPAddress )"
+    }
 }
 
 function ConvertFrom-RawNetAdapterInformation {


### PR DESCRIPTION
This early throw lets us detect this bug early instead of random places later in tests.