### PR TITLE
Disable docker's nat network in testbed template

### DIFF
--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -97,7 +97,6 @@
     state: directory
 
 - name: Disable docker's nat network
-  register: docker_config_file
   win_copy:
     dest: 'C:\ProgramData\Docker\config\daemon.json'
     content: |

--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -44,6 +44,12 @@
 - name: Install Docker-EE
   win_shell: "Install-Package Docker -ProviderName DockerProvider -Force"
 
+- name: Make sure docker is started
+  win_service:
+    name: Docker
+    state: started
+    start_mode: auto
+
 - name: Pull docker images
   win_shell: "docker pull {{ item }}"
   with_items:

--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -85,6 +85,20 @@
   win_shell: |
     Get-ContainerNetwork | Remove-ContainerNetwork -Force
 
+- name: Create docker config directory
+  win_file:
+    path: 'C:\ProgramData\Docker\config'
+    state: directory
+
+- name: Disable docker's nat network
+  register: docker_config_file
+  win_copy:
+    dest: 'C:\ProgramData\Docker\config\daemon.json'
+    content: |
+      {
+        "bridge" : "none"
+      }
+
 # Workaround (#1) for Docker/Windows behavior.
 # When WinNAT is enabled and NetNat object associated with default bridge
 # network created by Docker exists, ICMP/UDP packets bigger than MTU do


### PR DESCRIPTION
Template: `Template-testbed-201808130708`
[Jenkins job](http://10.84.12.26:8080/job/WinContrail-infra/job/templates/job/create-testbed-template/64/console)