### PR TITLE
Handle UPLOAD_ARTIFACTS in CI

### DIFF
--- a/CIScripts/BuildStage.ps1
+++ b/CIScripts/BuildStage.ps1
@@ -45,7 +45,7 @@ if ($NothingToBuild -or $CopyDisabledArtifacts) {
 }
 
 if (Test-Path Env:UPLOAD_ARTIFACTS) {
-    if ($Env:UPLOAD_ARTIFACTS -eq "yes") {
+    if ($Env:UPLOAD_ARTIFACTS -ne "0") {
         $ArtifactsPath = "\\$Env:SHARED_DRIVE_IP\SharedFiles\WindowsCI-UploadedArtifacts"
         $Subdir = "$Env:JOB_NAME\$Env:BUILD_NUMBER"
         $DiskName = [Guid]::newGuid().Guid

--- a/CIScripts/BuildStage.ps1
+++ b/CIScripts/BuildStage.ps1
@@ -45,15 +45,17 @@ if ($NothingToBuild -or $CopyDisabledArtifacts) {
 }
 
 if (Test-Path Env:UPLOAD_ARTIFACTS) {
-    $ArtifactsPath = "\\$Env:SHARED_DRIVE_IP\SharedFiles\WindowsCI-UploadedArtifacts"
-    $Subdir = "$Env:JOB_NAME\$Env:BUILD_NUMBER"
-    $DiskName = [Guid]::newGuid().Guid
-    New-PSDrive -Name $DiskName -PSProvider "FileSystem" -Root $ArtifactsPath -Credential $Credentials
-    Push-Location
-    Set-Location ($Diskname + ":\")
-    New-Item -Name $Subdir -ItemType directory
-    Pop-Location
-    Copy-Item ($OutputRootDirectory + "\*") -Destination ("$DiskName" + ":\" + $Subdir) -Recurse -Container
+    if ($Env:UPLOAD_ARTIFACTS -eq "yes") {
+        $ArtifactsPath = "\\$Env:SHARED_DRIVE_IP\SharedFiles\WindowsCI-UploadedArtifacts"
+        $Subdir = "$Env:JOB_NAME\$Env:BUILD_NUMBER"
+        $DiskName = [Guid]::newGuid().Guid
+        New-PSDrive -Name $DiskName -PSProvider "FileSystem" -Root $ArtifactsPath -Credential $Credentials
+        Push-Location
+        Set-Location ($Diskname + ":\")
+        New-Item -Name $Subdir -ItemType directory
+        Pop-Location
+        Copy-Item ($OutputRootDirectory + "\*") -Destination ("$DiskName" + ":\" + $Subdir) -Recurse -Container
+    }
 }
 
 exit 0


### PR DESCRIPTION
As you can see [here](http://10.84.12.26:8080/job/WinContrail/job/ci-contrail-windows-nightly-debug/configure) I specify `UPLOAD_ARTIFACTS=1`, but since [this job](http://10.84.12.26:8080/job/WinContrail/job/winci-server2016-prod) doesn't have this field, it's not passed there. For proof check [the Jenkins logs](http://10.84.12.26:8080/log/all):
```
Skipped parameter `UPLOAD_ARTIFACTS` as it is undefined on `WinContrail/winci-server2016-prod`.
```
Because of that reason I have to add the field `UPLOAD_ARTIFACTS` to winci-server2016-prod with default set to `0` and then set it to `1` in nightly.