### PR TITLE
Bump golang to 1.10.0.

### DIFF
--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -246,7 +246,7 @@
 - name: Install golang
   win_chocolatey:
     name: golang
-    version: 1.8.3
+    version: 1.10.0
     state: present
 
 - name: Install go-msi


### PR DESCRIPTION
This is because upgraded docker driver dependencies (hcsshim and
go-winio) rely on type aliasing mechanism, introduced in 1.9.0. But we
might as well skip to 1.10.0.