### PR TITLE
Support for release mode in nightly builds

### DIFF
--- a/CIScripts/Build.ps1
+++ b/CIScripts/Build.ps1
@@ -1,4 +1,7 @@
 # Build builds selected Windows Compute components.
+param(
+    [Parameter(Mandatory=$true)] [string] $BuildMode
+)
 
 . $PSScriptRoot\Common\Init.ps1
 . $PSScriptRoot\Common\Job.ps1
@@ -7,9 +10,6 @@
 
 
 $Job = [Job]::new("Build")
-
-$IsReleaseMode = [bool]::Parse($Env:BUILD_IN_RELEASE_MODE)
-$BuildMode = $(if ($IsReleaseMode) { "production" } else { "debug" })
 
 Initialize-BuildEnvironment -ThirdPartyCache $Env:THIRD_PARTY_CACHE_PATH
 

--- a/CIScripts/BuildStage.ps1
+++ b/CIScripts/BuildStage.ps1
@@ -9,8 +9,11 @@ $OutputRootDirectory = "output"
 $NothingToBuild = $Env:COMPONENTS_TO_BUILD -eq "None"
 $CopyDisabledArtifacts = Test-Path Env:COPY_DISABLED_ARTIFACTS
 
+$IsReleaseMode = [bool]::Parse($Env:BUILD_IN_RELEASE_MODE)
+$BuildMode = $(if ($IsReleaseMode) { "production" } else { "debug" })
+
 if (-not $NothingToBuild) {
-    & $PSScriptRoot\Build.ps1
+    & $PSScriptRoot\Build.ps1 -BuildMode $BuildMode
 }
 
 if ($NothingToBuild -or $CopyDisabledArtifacts) {
@@ -47,7 +50,7 @@ if ($NothingToBuild -or $CopyDisabledArtifacts) {
 if (Test-Path Env:UPLOAD_ARTIFACTS) {
     if ($Env:UPLOAD_ARTIFACTS -ne "0") {
         $ArtifactsPath = "\\$Env:SHARED_DRIVE_IP\SharedFiles\WindowsCI-UploadedArtifacts"
-        $Subdir = "$Env:JOB_NAME\$Env:BUILD_NUMBER"
+        $Subdir = "$BuildMode\$Env:JOB_NAME\$Env:BUILD_NUMBER"
         $DiskName = [Guid]::newGuid().Guid
         New-PSDrive -Name $DiskName -PSProvider "FileSystem" -Root $ArtifactsPath -Credential $Credentials
         Push-Location


### PR DESCRIPTION
Divide nightly artifacts built in release or debug mode by moving them
into different folders.