### PR TITLE
Add simple heuristic for fault detection.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,7 @@ pipeline {
                         unstash "CIScripts"
                         unstash "SourceCode"
 
-                        powershell script: './CIScripts/NoSuchFile.ps1'
+                        powershell script: './CIScripts/BuildStage.ps1'
 
                         stash name: "Artifacts", includes: "output/**/*"
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,7 @@ pipeline {
                         unstash "CIScripts"
                         unstash "SourceCode"
 
-                        powershell script: './CIScripts/BuildStage.ps1'
+                        powershell script: './CIScripts/NoSuchFile.ps1'
 
                         stash name: "Artifacts", includes: "output/**/*"
                     }

--- a/utility/split-log-into-stages.sh
+++ b/utility/split-log-into-stages.sh
@@ -29,7 +29,7 @@ do
     echo "copying '$stage' log to $stage_log_filename"
     grep --perl-regexp "$this_stage_regexp" "$full_log" | gzip > "$stage_log_filename"
 
-    if grep "Failed in branch" $stage_log_filename
+    if zgrep "Failed in branch" $stage_log_filename
     then
         mv $stage_log_filename "SUSPECTED-ERROR-HERE-$stage_log_filename"
     fi

--- a/utility/split-log-into-stages.sh
+++ b/utility/split-log-into-stages.sh
@@ -29,7 +29,7 @@ do
     echo "copying '$stage' log to $stage_log_filename"
     grep --perl-regexp "$this_stage_regexp" "$full_log" | gzip > "$stage_log_filename"
 
-    if grep "Failed in branch" temp.txt
+    if grep "Failed in branch" $stage_log_filename
     then
         mv $stage_log_filename "SUSPECTED-ERROR-HERE-$stage_log_filename"
     fi
@@ -42,6 +42,9 @@ grep --perl-regexp --invert-match "$stage_regexp" "$full_log" | gzip > "$non_tag
 echo "creating readme"
 cat > README << EOF
 The $full_log_gz contains the whole log of the check pipeline.
+
+Log file with SUSPECTED-ERROR-HERE prefix contains logs from failed job stage. Start looking
+for errors there.
 
 Additionally, logs from various stages are also available in log.<stage>.txt.gz files.
 Most likely, you'd want to check:

--- a/utility/split-log-into-stages.sh
+++ b/utility/split-log-into-stages.sh
@@ -28,6 +28,11 @@ do
     this_stage_regexp=$(get_stage_regexp "$stage")
     echo "copying '$stage' log to $stage_log_filename"
     grep --perl-regexp "$this_stage_regexp" "$full_log" | gzip > "$stage_log_filename"
+
+    if grep "Failed in branch" temp.txt
+    then
+        mv $stage_log_filename "SUSPECTED-ERROR-HERE-$stage_log_filename"
+    fi
 done
 
 non_tagged_filename='log.cloning-and-tests-and-post.txt.gz'


### PR DESCRIPTION
This should add a prefix to split log file that we suspect contains the error, based on Jenkins output when a stage is failed. This should make it easier to look for errors in logs.