### PR TITLE
Add min version requirement for PSScriptAnalyzer.

### DIFF
--- a/SELFCHECK.md
+++ b/SELFCHECK.md
@@ -4,7 +4,13 @@ CI has a set of unit and integration tests, called 'selfcheck'.
 
 ## Requirements
 
+### Tests
+
 Requires PowerShell test framework: `Pester 4.2.0`. See [this link](https://github.com/pester/Pester/wiki/Installation-and-Update) for installation instructions.
+
+### Static analysis (optional)
+
+Requires `PSScriptAnalyzer 17.0`. See [this link](https://github.com/PowerShell/PSScriptAnalyzer) for installation instructions.
 
 ## To run unit tests and static analysis of CI:
 

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -1,16 +1,25 @@
 Param([Parameter(Mandatory = $true)] [string] $RootDir,
-      [Parameter(Mandatory = $true)] [string] $ConfigDir)
+    [Parameter(Mandatory = $true)] [string] $ConfigDir)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$MinimumVersion = "1.17.0"
+try {
+    Get-Package -Name PSScriptAnalyzer -MinimumVersion $MinimumVersion | Out-Null
+} catch {
+    Write-Host "PSScriptAnalyzer not found. If you have installed it, make sure that it's at least version $MinimumVersion."
+    exit 1
+}
+
 $PSLinterConfig = "$ConfigDir/PSScriptAnalyzerSettings.psd1"
 Write-Host "Running PSScriptAnalyzer... (config from $PSLinterConfig)"
 
+
 $Output = Invoke-ScriptAnalyzer $RootDir -Recurse -Setting $PSLinterConfig
 if ($Output) {
-      Write-Host ($Output | Format-Table | Out-String)
-      exit 1
+    Write-Host ($Output | Format-Table | Out-String)
+    exit 1
 }
 
 exit 0

--- a/StaticAnalysis/README.md
+++ b/StaticAnalysis/README.md
@@ -8,6 +8,7 @@ To run all available linters, execute the following command in this directory:
 
 ## Powershell Script Analyzer (PSSCriptAnalyzer)
 
+Requires `PSScriptAnalyzer 17.0`. See [this link](https://github.com/PowerShell/PSScriptAnalyzer) for installation instructions.
 To run using our settings:
 
 ```

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -144,8 +144,9 @@
     allow_clobber: yes
 
 - name: Install PSScriptAnalyzer
-  win_psmodule:
-    name: PSScriptAnalyzer
+  win_chocolatey:
+    name: psscriptanalyzer
+    version: 1.17.0
     state: present
 
 - name: Install protoc-3.0.0 from github (GET)

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -105,7 +105,7 @@
 - name: Install ActivePerl Community Edition
   win_chocolatey:
     name: activeperl
-    version: 5.26.1.2601
+    version: 5.24.2.2403
     state: present
 
 - name: Install .NET Framework 3.5

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -105,7 +105,7 @@
 - name: Install ActivePerl Community Edition
   win_chocolatey:
     name: activeperl
-    version: 5.24.1.2402
+    version: 5.26.1.2601
     state: present
 
 - name: Install .NET Framework 3.5

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -146,7 +146,7 @@
 - name: Install PSScriptAnalyzer
   win_chocolatey:
     name: psscriptanalyzer
-    version: 1.17.0
+    version: 1.17.1
     state: present
 
 - name: Install protoc-3.0.0 from github (GET)


### PR DESCRIPTION
We need at least 1.17 because they fixed a bug with importing classes.

Template creation succeeds: http://10.84.12.26:8080/job/WinContrail-infra/job/templates/job/create-builder-template/120/