### PR TITLE
Add flag to starting docker-driver service

### DIFF
--- a/CIScripts/Testenv/Testenv.ps1
+++ b/CIScripts/Testenv/Testenv.ps1
@@ -14,6 +14,7 @@ class ControllerConfig {
     [string] $Address
     [int] $RestApiPort
     [string] $DefaultProject
+    [string] $AuthMethod
 
     [string] RestApiUrl() {
         return "http://$( $this.Address ):$( $this.RestApiPort )"

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -131,7 +131,8 @@ function Start-DockerDriver {
         "-adapter", $AdapterName,
         "-vswitchName", "Layered <adapter>",
         "-logPath", $OldLogPath,
-        "-logLevel", "Debug"
+        "-logLevel", "Debug",
+        "-authMethod", $ControllerConfig.AuthMethod
     )
 
     Invoke-Command -Session $Session -ScriptBlock {

--- a/Test/Tests/testenv-conf.yaml.sample
+++ b/Test/Tests/testenv-conf.yaml.sample
@@ -11,6 +11,7 @@ controller:
   restApiPort: 8082
   # Used by non-multitenancy tests
   defaultProject: ci_tests
+  authMethod: keystone
 
 testbeds:
   - name: <TESTBED1_NAME>

--- a/ansible/roles/testenv-save-conf/templates/testenv-conf.yaml.j2
+++ b/ansible/roles/testenv-save-conf/templates/testenv-conf.yaml.j2
@@ -13,6 +13,8 @@ controller:
   restApiPort: 8082
   # Used by non-multitenancy tests
   defaultProject: ci_tests
+  # Supported auth methods: keystone|noauth
+  authMethod: keystone
 
 testbeds:
 {% for testbed_name in groups['testbed'] %}


### PR DESCRIPTION
Docker driver now requires to specify the method of authentication.
Supported auth methods: keystone|noauth.