### PR TITLE
 Allow PSScriptAnalyzer installed by choco in Invoke script.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
                 }
 
                 stage('Static analysis - Windows') {
-                    agent { label 'builder' }
+                    agent { label 'builder-choco-analyzer' }
                     steps {
                         deleteDir()
                         unstash "StaticAnalysis"

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -11,12 +11,15 @@ function Assert-MeetsMinimalAnalyzerVersion($MinimumVersion) {
         $Analyzer = Get-Package -Name PSScriptAnalyzer
     } catch {
         # Maybe it was installed by chocolatey?
+        try {
+            Import-Module -Name PSScriptAnalyzer
+        } catch {
+            throw "PSScriptAnalyzer not found. Please install at least version $MinimumVersion."
+        }
         $Analyzer = Get-Module -Name PSScriptAnalyzer
     }
 
-    if (-not $Analyzer) {
-        throw "PSScriptAnalyzer not found. Please install at least version $MinimumVersion."
-    } elseif ($Analyzer.Version -lt $MinimumVersion) {
+    if ($Analyzer.Version -lt $MinimumVersion) {
         throw "PSScriptAnalyzer minimum version requirements not met. Make sure that it's at least version $MinimumVersion."
     } else {
         Write-Host "Found PSScriptAnalyzer in version $($Analyzer.Version)."

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -1,32 +1,46 @@
 Param([Parameter(Mandatory = $true)] [string] $RootDir,
-    [Parameter(Mandatory = $true)] [string] $ConfigDir)
+      [Parameter(Mandatory = $true)] [string] $ConfigDir,
+      [string] $MinimumVersion = "1.17.0")
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$MinimumVersion = "1.17.0"
-try {
-    Get-Package -Name PSScriptAnalyzer -MinimumVersion $MinimumVersion | Out-Null
-} catch {
-    Write-Host "PSScriptAnalyzer not found. If you have installed it, make sure that it's at least version $MinimumVersion."
-    exit 1
+function Test-MinimalAnalyzerVersion($MinimumVersion) {
+    try {
+        # Maybe it was installed using PSGet?
+        $Analyzer = Get-Package -Name PSScriptAnalyzer
+    } catch {
+        # Maybe it was installed by chocolatey?
+        $Analyzer = Get-Module -Name PSScriptAnalyzer
+    }
+    if ($Analyzer.Version -lt $MinimumVersion) {
+        Write-Host "PSScriptAnalyzer not found. If you have installed it, make sure that it's at least version $MinimumVersion."
+        exit 1
+    }
+}
+
+function Remove-TypeNotFoundWarning ($Data) {
+    # WORKAROUND
+    # TypeNotFound error is fixed in 1.17.0 PSScriptAnalyzer, but it still produces a warning.
+    # Moreover, this warning cannot be surpressed in script analyzer settings. 
+    # We still want to treat warnings as errors, so the only way is to filter out this warning
+    # out of the analyzer output. Until issue [1] is resolved TypeNotFound cannot be
+    # suppressed like all the other errors.
+    # [1] https://github.com/PowerShell/PSScriptAnalyzer/issues/1041
+    $Output | Where-Object -FilterScript { $_.RuleName -ne "TypeNotFound" }
+}
+
+function Write-Results ($Data) {
+    Write-Host ($Data | Format-Table | Out-String)
 }
 
 $PSLinterConfig = "$ConfigDir/PSScriptAnalyzerSettings.psd1"
 Write-Host "Running PSScriptAnalyzer... (config from $PSLinterConfig)"
-
-
+Test-MinimalAnalyzerVersion($MinimumVersion)
 $Output = Invoke-ScriptAnalyzer $RootDir -Recurse -Setting $PSLinterConfig
-
-# TypeNotFound errors are still reported. Until this issue [1] is resolved TypeNotFound cannot be
-# suppressed like all the other errors.
-#
-# [1] https://github.com/PowerShell/PSScriptAnalyzer/issues/1041
-$Output = $Output | Where-Object -FilterScript { $_.RuleName -ne "TypeNotFound" }
-
+$Output = Remove-TypeNotFoundWarning $Output
 if ($Output) {
-    Write-Host ($Output | Format-Table | Out-String)
+    Write-Results $Output
     exit 1
 }
-
 exit 0

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -13,8 +13,11 @@ function Test-MinimalAnalyzerVersion($MinimumVersion) {
         # Maybe it was installed by chocolatey?
         $Analyzer = Get-Module -Name PSScriptAnalyzer
     }
-    if ($Analyzer.Version -lt $MinimumVersion) {
-        Write-Host "PSScriptAnalyzer not found. If you have installed it, make sure that it's at least version $MinimumVersion."
+    if (-not $Analyzer) {
+        Write-Host "PSScriptAnalyzer not found. Please install at least version $MinimumVersion."
+        exit 1
+    } else if ($Analyzer.Version -lt $MinimumVersion) {
+        Write-Host "PSScriptAnalyzer minimum version requirements not met. Make sure that it's at least version $MinimumVersion."
         exit 1
     }
 }

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -13,12 +13,13 @@ function Assert-MeetsMinimalAnalyzerVersion($MinimumVersion) {
         # Maybe it was installed by chocolatey?
         $Analyzer = Get-Module -Name PSScriptAnalyzer
     }
+
     if (-not $Analyzer) {
-        Write-Host "PSScriptAnalyzer not found. Please install at least version $MinimumVersion."
-        exit 1
+        throw "PSScriptAnalyzer not found. Please install at least version $MinimumVersion."
     } elseif ($Analyzer.Version -lt $MinimumVersion) {
-        Write-Host "PSScriptAnalyzer minimum version requirements not met. Make sure that it's at least version $MinimumVersion."
-        exit 1
+        throw "PSScriptAnalyzer minimum version requirements not met. Make sure that it's at least version $MinimumVersion."
+    } else {
+        Write-Host "Found PSScriptAnalyzer in version $($Analyzer.Version)."
     }
 }
 

--- a/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
+++ b/StaticAnalysis/Invoke-StaticAnalysisTools.ps1
@@ -5,7 +5,7 @@ Param([Parameter(Mandatory = $true)] [string] $RootDir,
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-function Test-MinimalAnalyzerVersion($MinimumVersion) {
+function Assert-MeetsMinimalAnalyzerVersion($MinimumVersion) {
     try {
         # Maybe it was installed using PSGet?
         $Analyzer = Get-Package -Name PSScriptAnalyzer
@@ -16,7 +16,7 @@ function Test-MinimalAnalyzerVersion($MinimumVersion) {
     if (-not $Analyzer) {
         Write-Host "PSScriptAnalyzer not found. Please install at least version $MinimumVersion."
         exit 1
-    } else if ($Analyzer.Version -lt $MinimumVersion) {
+    } elseif ($Analyzer.Version -lt $MinimumVersion) {
         Write-Host "PSScriptAnalyzer minimum version requirements not met. Make sure that it's at least version $MinimumVersion."
         exit 1
     }
@@ -39,7 +39,7 @@ function Write-Results ($Data) {
 
 $PSLinterConfig = "$ConfigDir/PSScriptAnalyzerSettings.psd1"
 Write-Host "Running PSScriptAnalyzer... (config from $PSLinterConfig)"
-Test-MinimalAnalyzerVersion($MinimumVersion)
+Assert-MeetsMinimalAnalyzerVersion($MinimumVersion)
 $Output = Invoke-ScriptAnalyzer $RootDir -Recurse -Setting $PSLinterConfig
 $Output = Remove-TypeNotFoundWarning $Output
 if ($Output) {


### PR DESCRIPTION
We used to install PSScriptAnalyzer using PSget. So we checked its
version using Get-Package. But now it's installed by chocolatey, so it
doesn't appear in Get-Package. Instead, we need to check Get-Module.
