### PR TITLE
builder: Docker installation

### DIFF
--- a/ansible/builders.yml
+++ b/ansible/builders.yml
@@ -1,0 +1,5 @@
+---
+
+- hosts: builder
+  roles:
+    - builder

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -137,12 +137,6 @@
     version: 4.5.1
     state: present
 
-- name: Install PowerShell Community Extensions (PSCX)
-  win_psmodule:
-    name: Pscx
-    state: present
-    allow_clobber: yes
-
 - name: Install PSScriptAnalyzer
   win_chocolatey:
     name: psscriptanalyzer

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -34,8 +34,6 @@
     pre_reboot_delay: 15
     post_reboot_delay: 15
   when: hyperv_installation.reboot_required or hyperv_installation.feature_result.reboot_required
-  tags:
-    - skip_ansible_lint
 
 - name: Wait for reconnection
   wait_for_connection:

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -12,6 +12,63 @@
   include_role:
     name: windows-ntp
 
+- name: Install Windows-Containers feature
+  win_feature:
+    name: Containers
+    state: present
+  tags:
+    - builder_docker
+
+- name: Install feature NET-Framework-Features
+  win_feature:
+    name: 'NET-Framework-Features'
+    state: present
+  tags:
+    - builder_docker
+
+- name: Install Hyper-V feature
+  win_feature:
+    name: Hyper-V
+    include_management_tools: true
+    state: present
+  register: hyperv_installation
+  tags:
+    - builder_docker
+
+- name: Reboot the system
+  win_reboot:
+    test_command: powershell.exe 'Get-WindowsFeature'
+    pre_reboot_delay: 15
+    post_reboot_delay: 15
+  when: hyperv_installation is changed
+  tags:
+    - builder_docker
+    - skip_ansible_lint
+
+- name: Wait for reconnection
+  wait_for_connection:
+  tags:
+    - builder_docker
+
+- name: Install DockerMsftProvider
+  win_psmodule:
+    name: DockerMsftProvider
+  tags:
+    - builder_docker
+
+- name: Install Docker-EE
+  win_shell: "Install-Package -Name Docker -ProviderName DockerMsftProvider -Force"
+  tags:
+    - builder_docker
+
+- name: Make sure Docker has started
+  win_service:
+    name: Docker
+    state: started
+    start_mode: auto
+  tags:
+    - builder_docker
+
 - name: Install .NET 3.5
   win_feature:
     name: NET-Framework-Core

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -40,7 +40,7 @@
     test_command: powershell.exe 'Get-WindowsFeature'
     pre_reboot_delay: 15
     post_reboot_delay: 15
-  when: hyperv_installation is changed
+  when: hyperv_installation.reboot_required
   tags:
     - builder_docker
     - skip_ansible_lint

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -16,15 +16,11 @@
   win_feature:
     name: Containers
     state: present
-  tags:
-    - builder_docker
 
 - name: Install feature NET-Framework-Features
   win_feature:
     name: 'NET-Framework-Features'
     state: present
-  tags:
-    - builder_docker
 
 - name: Install Hyper-V feature
   win_feature:
@@ -32,8 +28,6 @@
     include_management_tools: true
     state: present
   register: hyperv_installation
-  tags:
-    - builder_docker
 
 - name: Reboot the system
   win_reboot:
@@ -42,24 +36,17 @@
     post_reboot_delay: 15
   when: hyperv_installation.reboot_required
   tags:
-    - builder_docker
     - skip_ansible_lint
 
 - name: Wait for reconnection
   wait_for_connection:
-  tags:
-    - builder_docker
 
 - name: Install DockerMsftProvider
   win_psmodule:
     name: DockerMsftProvider
-  tags:
-    - builder_docker
 
 - name: Install Docker-EE
   win_shell: "Install-Package -Name Docker -ProviderName DockerMsftProvider -Force"
-  tags:
-    - builder_docker
 
 - name: Make sure Docker has started
   win_service:

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -31,10 +31,9 @@
 
 - name: Reboot the system
   win_reboot:
-    test_command: powershell.exe 'Get-WindowsFeature'
     pre_reboot_delay: 15
     post_reboot_delay: 15
-  when: hyperv_installation.reboot_required
+  when: hyperv_installation.reboot_required or hyperv_installation.feature_result.reboot_required
   tags:
     - skip_ansible_lint
 

--- a/ansible/roles/builder/tasks/main.yml
+++ b/ansible/roles/builder/tasks/main.yml
@@ -66,8 +66,6 @@
     name: Docker
     state: started
     start_mode: auto
-  tags:
-    - builder_docker
 
 - name: Install .NET 3.5
   win_feature:

--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -26,9 +26,9 @@
     include_management_tools: True
     state: present
 
-- name: Install DockerProvider
+- name: Install DockerMsftProvider
   win_psmodule:
-    name: DockerProvider
+    name: DockerMsftProvider
 
 - name: Reboot the system
   win_reboot:
@@ -42,7 +42,7 @@
   wait_for_connection:
 
 - name: Install Docker-EE
-  win_shell: "Install-Package Docker -ProviderName DockerProvider -Force"
+  win_shell: "Install-Package Docker -ProviderName DockerMsftProvider -Force"
 
 - name: Make sure docker is started
   win_service:

--- a/ansible/roles/testbed/tasks/main.yml
+++ b/ansible/roles/testbed/tasks/main.yml
@@ -35,8 +35,6 @@
     test_command: powershell.exe 'Get-WindowsFeature'
     pre_reboot_delay: 15
     post_reboot_delay: 15
-  tags:
-    - skip_lint
 
 - name: Wait for reconnection
   wait_for_connection:


### PR DESCRIPTION
- Removed PSCX installation since Ansible _promises_ that `.zip` archives are supported natively:
    - https://docs.ansible.com/ansible/2.4/win_unzip_module.html#synopsis
- Add Docker installation to builder role. Used in nightly builds.
- Add playbook for updating builders.

TO DO:

- [x] Create a builder template to test PSCX installation