### PR TITLE
Initialize compute nodes once in TunnellingWithAgent tests

### DIFF
--- a/Test/PesterLogger/RemoteLogCollector.Tests.ps1
+++ b/Test/PesterLogger/RemoteLogCollector.Tests.ps1
@@ -54,7 +54,7 @@ Describe "RemoteLogCollector" -Tags CI, Unit {
 
         Merge-Logs -LogSources $Source1
 
-        Test-Path $DummyLog1 | Should -Be $false
+        Get-Content $DummyLog1 | Should -Be $null
     }
 
     It "doesn't clean logs in source directory if DontCleanUp flag passed" {
@@ -63,7 +63,7 @@ Describe "RemoteLogCollector" -Tags CI, Unit {
 
         Merge-Logs -DontCleanUp -LogSources $Source1
 
-        Test-Path $DummyLog1 | Should -Be $true
+        Get-Content $DummyLog1 | Should -Not -Be $null
     }
 
     It "tags the messages with file basename" {

--- a/Test/PesterLogger/RemoteLogCollector.ps1
+++ b/Test/PesterLogger/RemoteLogCollector.ps1
@@ -74,10 +74,10 @@ class FileLogSource : LogSource {
             $Files = Get-ChildItem -Path $What -ErrorAction SilentlyContinue
             foreach ($File in $Files) {
                 try {
-                    Remove-Item $File
+                    Clear-Content $File -Force
                 }
                 catch {
-                    Write-Warning "$File was not removed due to $_"
+                    Write-Warning "$File was not cleared due to $_"
                 }
             }
         }
@@ -186,4 +186,11 @@ function Merge-Logs {
     }
 
     Write-Log ("=" * 100)
+}
+
+function Clear-Logs {
+    Param([Parameter(Mandatory = $true)] [LogSource[]] $LogSources)
+    foreach ($LogSource in $LogSources) {
+        $LogSource.ClearContent()
+    }
 }

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -148,8 +148,10 @@ function Start-DockerDriver {
             $LogPath = Join-Path $LogDir "contrail-windows-docker-driver.log"
             $ErrorActionPreference = "Continue"
 
+            # "Out-File -Append" in contrary to "Add-Content" doesn't require a read lock, so logs can
+            # be read while the process is running
             & "C:\Program Files\Juniper Networks\contrail-windows-docker.exe" $Arguments 2>&1 |
-                Add-Content -NoNewline $LogPath
+                Out-File -Append -FilePath $LogPath
         } -ArgumentList $Arguments, $LogDir
     }
 

--- a/Test/Tests/Network/TunnellingWithAgent.Tests.ps1
+++ b/Test/Tests/Network/TunnellingWithAgent.Tests.ps1
@@ -410,16 +410,25 @@ Describe "Tunneling with Agent tests" {
         Initialize-PesterLogger -OutDir $LogDir
         $MultiNode = New-MultiNodeSetup -TestenvConfFile $TestenvConfFile
 
-        Write-Log "Creating virtual network: $Network.Name"
+        Write-Log "Creating virtual network: $($Network.Name)"
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
             "PSUseDeclaredVarsMoreThanAssignments",
             "ContrailNetwork",
             Justification="It's actually used."
         )]
         $ContrailNetwork = $MultiNode.NM.AddNetwork($null, $Network.Name, $Subnet)
+
+        Initialize-ComputeNode -Session $MultiNode.Sessions[0] -Networks @($Network) -Configs $MultiNode.Configs
+        Initialize-ComputeNode -Session $MultiNode.Sessions[1] -Networks @($Network) -Configs $MultiNode.Configs
     }
 
     AfterAll {
+        $Sessions = $MultiNode.Sessions
+        $SystemConfig = $MultiNode.Configs.System
+        Clear-TestConfiguration -Session $Sessions[0] -SystemConfig $SystemConfig
+        Clear-TestConfiguration -Session $Sessions[1] -SystemConfig $SystemConfig
+        Clear-Logs -LogSources (New-FileLogSource -Path (Get-ComputeLogsPath) -Sessions $Sessions)
+
         if (Get-Variable "MultiNode" -ErrorAction SilentlyContinue) {
             Write-Log "Deleting virtual network"
             if (Get-Variable ContrailNetwork -ErrorAction SilentlyContinue) {
@@ -432,9 +441,6 @@ Describe "Tunneling with Agent tests" {
     }
 
     BeforeEach {
-        Initialize-ComputeNode -Session $MultiNode.Sessions[0] -Networks @($Network) -Configs $MultiNode.Configs
-        Initialize-ComputeNode -Session $MultiNode.Sessions[1] -Networks @($Network) -Configs $MultiNode.Configs
-
         Write-Log "Creating containers"
         Write-Log "Creating container: $Container1ID"
         New-Container `
@@ -472,8 +478,6 @@ Describe "Tunneling with Agent tests" {
 
     AfterEach {
         $Sessions = $MultiNode.Sessions
-        $SystemConfig = $MultiNode.Configs.System
-
         try {
             Merge-Logs -LogSources (
                 (New-ContainerLogSource -Sessions $Sessions[0] -ContainerNames $Container1ID),
@@ -482,11 +486,8 @@ Describe "Tunneling with Agent tests" {
 
             Write-Log "Removing all containers"
             Remove-AllContainers -Sessions $Sessions
-
-            Clear-TestConfiguration -Session $Sessions[0] -SystemConfig $SystemConfig
-            Clear-TestConfiguration -Session $Sessions[1] -SystemConfig $SystemConfig
         } finally {
-            Merge-Logs -LogSources (New-FileLogSource -Path (Get-ComputeLogsPath) -Sessions $Sessions)
+            Merge-Logs -DontCleanUp -LogSources (New-FileLogSource -Path (Get-ComputeLogsPath) -Sessions $Sessions)
         }
     }
 }


### PR DESCRIPTION
This will better reflect normal user environment and hopefully reduce
random tests' failures.