### PR TITLE
jenkins: Use builder label in Static analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
                 }
 
                 stage('Static analysis - Windows') {
-                    agent { label 'builder-choco-analyzer' }
+                    agent { label 'builder' }
                     steps {
                         deleteDir()
                         unstash "StaticAnalysis"


### PR DESCRIPTION
Since PSScriptAnalyser is already deployed on builder nodes, `builder-choco-analyzer` label can removed.