### PR TITLE
c-a-d: Limit Java memory usage

### DIFF
--- a/ansible/roles/contrail-ansible-deployer/templates/instances.j2
+++ b/ansible/roles/contrail-ansible-deployer/templates/instances.j2
@@ -38,6 +38,7 @@ contrail_configuration:
   KEYSTONE_AUTH_URL_VERSION: "/v3"
   RABBITMQ_NODE_PORT: 5673
 {% endif %}
+  JVM_EXTRA_OPTS: "-Xms1g -Xmx2g"
 kolla_config:
   kolla_globals:
     network_interface: "{{ network_interface }}"


### PR DESCRIPTION
Added Java options to limit a maximum allocation pool to 2 GB, to avoid _hungry Cassandra_ syndrome.