### PR TITLE
Move Test- methods to separate directory.

### DIFF
--- a/Test/Tests/Network/FloatingIP.Tests.ps1
+++ b/Test/Tests/Network/FloatingIP.Tests.ps1
@@ -10,28 +10,11 @@ Param (
 . $PSScriptRoot\..\..\PesterLogger\RemoteLogCollector.ps1
 . $PSScriptRoot\..\..\TestConfigurationUtils.ps1
 . $PSScriptRoot\..\..\Utils\ComponentsInstallation.ps1
+. $PSScriptRoot\..\..\Utils\Network\Connectivity.ps1
 . $PSScriptRoot\..\..\Utils\ComputeNode\Initialize.ps1
 . $PSScriptRoot\..\..\Utils\ContrailNetworkManager.ps1
 . $PSScriptRoot\..\..\Utils\DockerNetwork\DockerNetwork.ps1
 . $PSScriptRoot\..\..\Utils\MultiNode\ContrailMultiNodeProvisioning.ps1
-
-function Test-Ping {
-    Param (
-        [Parameter(Mandatory=$true)] [PSSessionT] $Session,
-        [Parameter(Mandatory=$true)] [String] $SrcContainerName,
-        [Parameter(Mandatory=$true)] [String] $DstIP,
-        [Parameter(Mandatory=$false)] [Int] $BufferSize = 32
-    )
-
-    Write-Log "Container $SrcContainerName is pinging $DstIP..."
-    $Res = Invoke-Command -Session $Session -ScriptBlock {
-        docker exec $Using:SrcContainerName powershell `
-            "ping -l $Using:BufferSize $Using:DstIP; `$LASTEXITCODE;"
-    }
-    $Output = $Res[0..($Res.length - 2)]
-    Write-Log "Ping output: $Output"
-    return $Res[-1]
-}
 
 $PolicyName = "passallpolicy"
 

--- a/Test/Utils/Network/Connectivity.ps1
+++ b/Test/Utils/Network/Connectivity.ps1
@@ -1,0 +1,87 @@
+. $PSScriptRoot/UDPClient.ps1
+. $PSScriptRoot/UDPEchoServer.ps1
+
+function Test-Ping {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session,
+        [Parameter(Mandatory=$true)] [String] $SrcContainerName,
+        [Parameter(Mandatory=$true)] [String] $DstIP,
+        [Parameter(Mandatory=$false)] [String] $DstContainerName = $DstIP,
+        [Parameter(Mandatory=$false)] [Int] $BufferSize = 32
+    )
+
+    Write-Log "Container $SrcContainerName is pinging $DstContainerName..."
+    $Res = Invoke-Command -Session $Session -ScriptBlock {
+        docker exec $Using:SrcContainerName powershell `
+            "ping -l $Using:BufferSize $Using:DstIP; `$LASTEXITCODE;"
+    }
+    $Output = $Res[0..($Res.length - 2)]
+    Write-Log "Ping output: $Output"
+    return $Res[-1]
+}
+
+function Test-TCP {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session,
+        [Parameter(Mandatory=$true)] [String] $SrcContainerName,
+        [Parameter(Mandatory=$true)] [String] $DstIP,
+        [Parameter(Mandatory=$false)] [String] $DstContainerName = $DspTIP
+    )
+
+    Write-Log "Container $SrcContainerName is sending HTTP request to $DstContainerName..."
+    $Res = Invoke-Command -Session $Session -ScriptBlock {
+        docker exec $Using:SrcContainerName powershell `
+            "Invoke-WebRequest -Uri http://${Using:DstIP}:8080/ -UseBasicParsing -ErrorAction Continue; `$LASTEXITCODE"
+    }
+    $Output = $Res[0..($Res.length - 2)]
+    Write-Log "Web request output: $Output"
+    return $Res[-1]
+}
+
+function Test-UDP {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $ListenerContainerSession,
+        [Parameter(Mandatory=$true)] [PSSessionT] $ClientContainerSession,
+        [Parameter(Mandatory=$true)] [String] $ListenerContainerName,
+        [Parameter(Mandatory=$true)] [String] $ListenerContainerIP,
+        [Parameter(Mandatory=$true)] [String] $ClientContainerName,
+        [Parameter(Mandatory=$true)] [String] $Message,
+        [Parameter(Mandatory=$false)] [Int16] $UDPServerPort = 1111,
+        [Parameter(Mandatory=$false)] [Int16] $UDPClientPort = 2222
+    )
+
+    Write-Log "Starting UDP Echo server on container $ListenerContainerName ..."
+    Start-UDPEchoServerInContainer `
+        -Session $ListenerContainerSession `
+        -ContainerName $ListenerContainerName `
+        -ServerPort $UDPServerPort `
+        -ClientPort $UDPClientPort
+
+    Write-Log "Starting UDP listener on container $ClientContainerName..."
+    Start-UDPListenerInContainer `
+        -Session $ClientContainerSession `
+        -ContainerName $ClientContainerName `
+        -ListenerPort $UDPClientPort
+
+    Write-Log "Sending UDP packet from container $ClientContainerName..."
+    Send-UDPFromContainer `
+        -Session $ClientContainerSession `
+        -ContainerName $ClientContainerName `
+        -ListenerIP $ListenerContainerIP `
+        -Message $Message `
+        -ListenerPort $UDPServerPort `
+        -NumberOfAttempts 10 `
+        -WaitSeconds 1
+
+    Write-Log "Fetching results from listener job..."
+    $ReceivedMessage = Stop-UDPListenerInContainerAndFetchResult -Session $ClientContainerSession
+    Stop-EchoServerInContainer -Session $ListenerContainerSession
+
+    Write-Log "Sent message: $Message"
+    Write-Log "Received message: $ReceivedMessage"
+    if ($ReceivedMessage -eq $Message) {
+        return $true
+    } else {
+        return $false
+    }
+}

--- a/Test/Utils/Network/UDPClient.ps1
+++ b/Test/Utils/Network/UDPClient.ps1
@@ -1,0 +1,24 @@
+function Send-UDPFromContainer {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session,
+        [Parameter(Mandatory=$true)] [String] $ContainerName,
+        [Parameter(Mandatory=$true)] [String] $Message,
+        [Parameter(Mandatory=$true)] [String] $ListenerIP,
+        [Parameter(Mandatory=$true)] [Int16] $ListenerPort,
+        [Parameter(Mandatory=$true)] [Int16] $NumberOfAttempts,
+        [Parameter(Mandatory=$true)] [Int16] $WaitSeconds
+    )
+    $UDPSendCommand = (
+    '$EchoServerAddress = New-Object System.Net.IPEndPoint([IPAddress]::Parse(\"{0}\"), {1});' + `
+    '$UDPSenderSocket = New-Object System.Net.Sockets.UdpClient 0;' + `
+    '$Payload = [Text.Encoding]::UTF8.GetBytes(\"{2}\");' + `
+    '1..{3} | ForEach-Object {{' + `
+    '    $UDPSenderSocket.Send($Payload, $Payload.Length, $EchoServerAddress);' + `
+    '    Start-Sleep -Seconds {4};' + `
+    '}}') -f $ListenerIP, $ListenerPort, $Message, $NumberOfAttempts, $WaitSeconds
+
+    $Output = Invoke-Command -Session $Session -ScriptBlock {
+        docker exec $Using:ContainerName powershell "$Using:UDPSendCommand"
+    }
+    Write-Log "Send UDP output from remote session: $Output"
+}

--- a/Test/Utils/Network/UDPEchoServer.ps1
+++ b/Test/Utils/Network/UDPEchoServer.ps1
@@ -1,0 +1,89 @@
+function Start-UDPEchoServerInContainer {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session,
+        [Parameter(Mandatory=$true)] [String] $ContainerName,
+        [Parameter(Mandatory=$true)] [Int16] $ServerPort,
+        [Parameter(Mandatory=$true)] [Int16] $ClientPort
+    )
+    $UDPEchoServerCommand = ( `
+    '$SendPort = {0};' + `
+    '$RcvPort = {1};' + `
+    '$IPEndpoint = New-Object System.Net.IPEndPoint([IPAddress]::Any, $RcvPort);' + `
+    '$RemoteIPEndpoint = New-Object System.Net.IPEndPoint([IPAddress]::Any, 0);' + `
+    '$UDPSocket = New-Object System.Net.Sockets.UdpClient;' + `
+    '$UDPSocket.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true);' + `
+    '$UDPSocket.Client.Bind($IPEndpoint);' + `
+    'while($true) {{' + `
+    '    try {{' + `
+    '        $Payload = $UDPSocket.Receive([ref]$RemoteIPEndpoint);' + `
+    '        $RemoteIPEndpoint.Port = $SendPort;' + `
+    '        $UDPSocket.Send($Payload, $Payload.Length, $RemoteIPEndpoint);' + `
+    '        \"Received message and sent it to: $RemoteIPEndpoint.\" | Out-String;' + `
+    '    }} catch {{ Write-Output $_.Exception; continue }}' + `
+    '}}') -f $ClientPort, $ServerPort
+
+    Invoke-Command -Session $Session -ScriptBlock {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+            "PSUseDeclaredVarsMoreThanAssignments",
+            "UDPEchoServerJob",
+            Justification="It's actually used."
+        )]
+        $UDPEchoServerJob = Start-Job -ScriptBlock {
+            param($ContainerName, $UDPEchoServerCommand)
+            docker exec $ContainerName powershell "$UDPEchoServerCommand"
+        } -ArgumentList $Using:ContainerName, $Using:UDPEchoServerCommand
+    }
+}
+
+function Stop-EchoServerInContainer {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session
+    )
+
+    $Output = Invoke-Command -Session $Session -ScriptBlock {
+        $UDPEchoServerJob | Stop-Job | Out-Null
+        $Output = Receive-Job -Job $UDPEchoServerJob
+        return $Output
+    }
+
+    Write-Log "Output from UDP echo server running in remote session: $Output"
+}
+
+function Start-UDPListenerInContainer {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session,
+        [Parameter(Mandatory=$true)] [String] $ContainerName,
+        [Parameter(Mandatory=$true)] [Int16] $ListenerPort
+    )
+    $UDPListenerCommand = ( `
+    '$RemoteIPEndpoint = New-Object System.Net.IPEndPoint([IPAddress]::Any, 0);' + `
+    '$UDPRcvSocket = New-Object System.Net.Sockets.UdpClient {0};' + `
+    '$Payload = $UDPRcvSocket.Receive([ref]$RemoteIPEndpoint);' + `
+    '[Text.Encoding]::UTF8.GetString($Payload)') -f $ListenerPort
+
+    Invoke-Command -Session $Session -ScriptBlock {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+            "PSUseDeclaredVarsMoreThanAssignments",
+            "UDPListenerJob",
+            Justification="It's actually used."
+        )]
+        $UDPListenerJob = Start-Job -ScriptBlock {
+            param($ContainerName, $UDPListenerCommand)
+            & docker exec $ContainerName powershell "$UDPListenerCommand"
+        } -ArgumentList $Using:ContainerName, $Using:UDPListenerCommand
+    }
+}
+
+function Stop-UDPListenerInContainerAndFetchResult {
+    Param (
+        [Parameter(Mandatory=$true)] [PSSessionT] $Session
+    )
+
+    $Message = Invoke-Command -Session $Session -ScriptBlock {
+        $UDPListenerJob | Wait-Job -Timeout 30 | Out-Null
+        $ReceivedMessage = Receive-Job -Job $UDPListenerJob
+        return $ReceivedMessage
+    }
+    Write-Log "UDP listener output from remote session: $Message"
+    return $Message
+}


### PR DESCRIPTION
Test suite files were getting too cluttered and there was some duplication with Test-Ping.

(Not only it is used between two files, but also move tests that would use it are coming soon - DNS).