### PR TITLE
Add retries to session connection and publishing monitoring scripts.

### DIFF
--- a/CIScripts/Testenv/Testbed.ps1
+++ b/CIScripts/Testenv/Testbed.ps1
@@ -16,13 +16,18 @@ function Get-TestbedCredential {
 }
 
 function New-RemoteSessions {
-    Param ([Parameter(Mandatory = $true)] [Hashtable[]] $VMs)
+    Param (
+        [Parameter(Mandatory = $true)] [Hashtable[]] $VMs,
+        $RetryCount = 10,
+        $Timeout = 300000
+    )
 
     $Sessions = [System.Collections.ArrayList] @()
     foreach ($VM in $VMs) {
         $Creds = Get-TestbedCredential -VM $VM
         $Sess = if ($VM['Address']) {
-            New-PSSession -ComputerName $VM.Address -Credential $Creds
+            $pso = New-PSSessionOption -MaxConnectionRetryCount $RetryCount -OperationTimeout $Timeout
+            New-PSSession -ComputerName $VM.Address -Credential $Creds -SessionOption $pso
         } elseif ($VM['VMName']) {
             New-PSSession -VMName $VM.VMName -Credential $Creds
         } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,16 +358,18 @@ pipeline {
                     def fullLogsURL = logsURL(env.LOG_SERVER, env.LOG_SERVER_FOLDER, relLogsDstDir)
 
                     unstash "Monitoring"
-                    shellCommand('python3', [
-                        'monitoring/collect_and_push_build_stats.py',
-                        '--job-name', env.JOB_NAME,
-                        '--job-status', currentBuild.currentResult,
-                        '--build-url', env.BUILD_URL,
-                        '--mysql-host', env.MYSQL_HOST,
-                        '--mysql-database', env.MYSQL_DATABASE,
-                        '--mysql-username', env.MYSQL_USR,
-                        '--mysql-password', env.MYSQL_PSW,
-                    ] + getReportsLocationParam(fullLogsURL))
+                    retry(3){
+                        shellCommand('python3', [
+                            'monitoring/collect_and_push_build_stats.py',
+                            '--job-name', env.JOB_NAME,
+                            '--job-status', currentBuild.currentResult,
+                            '--build-url', env.BUILD_URL,
+                            '--mysql-host', env.MYSQL_HOST,
+                            '--mysql-database', env.MYSQL_DATABASE,
+                            '--mysql-username', env.MYSQL_USR,
+                            '--mysql-password', env.MYSQL_PSW,
+                        ] + getReportsLocationParam(fullLogsURL))
+                    }
                 }
             }
         }


### PR DESCRIPTION
If connection breaks during publishing monitoring scripts whole job
fails even if tests pass - retries will solve part of this problem.
Sensible retries to session connection are added as well.