### PR TITLE
Debug output for Agent's REST API port getting locked

### DIFF
--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -204,10 +204,12 @@ function Enable-AgentService {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session)
 
     Write-Log "Starting Agent"
-    Invoke-NativeCommand -Session $Session -ScriptBlock {
-        netstat -abq #dial tcp bug debug output
+    $Output = Invoke-NativeCommand -Session $Session -ScriptBlock {
+        $Output = netstat -abq #dial tcp bug debug output
         Start-Service ContrailAgent
+        return $Output
     }
+    Write-Log $Output
 }
 
 function Disable-AgentService {

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -205,11 +205,11 @@ function Enable-AgentService {
 
     Write-Log "Starting Agent"
     $Output = Invoke-NativeCommand -Session $Session -ScriptBlock {
-        $Output = netstat -abq #dial tcp bug debug output
+        $Output = netstat -abq  #dial tcp bug debug output
         Start-Service ContrailAgent
         return $Output
-    }
-    Write-Log $Output
+    } -CaptureOutput
+    Write-Log $Output.Output
 }
 
 function Disable-AgentService {

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -204,9 +204,9 @@ function Enable-AgentService {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session)
 
     Write-Log "Starting Agent"
-    Invoke-Command -Session $Session -ScriptBlock {
+    Invoke-NativeCommand -Session $Session -ScriptBlock {
         netstat -abq #dial tcp bug debug output
-        Start-Service ContrailAgent | Out-Null
+        Start-Service ContrailAgent
     }
 }
 

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -205,6 +205,7 @@ function Enable-AgentService {
 
     Write-Log "Starting Agent"
     Invoke-Command -Session $Session -ScriptBlock {
+        netstat -abq #dial tcp bug debug output
         Start-Service ContrailAgent | Out-Null
     }
 }


### PR DESCRIPTION
Because I do not know the way to reproduce this bug, we need to add debug output to verify what process locks agent's REST API port.