### PR TITLE
Remove `allow unused-imports` for shelly is fixed

### DIFF
--- a/Test/PesterLogger/PesterLogger.ps1
+++ b/Test/PesterLogger/PesterLogger.ps1
@@ -1,7 +1,7 @@
 . $PSScriptRoot\..\..\CIScripts\Common\Aliases.ps1
 
-# [Shelly-Bug] Shelly doesn't detect imported classes yet.
-. $PSScriptRoot\Get-CurrentPesterScope.ps1 # allow unused-imports
+# [Shelly-Bug] Shelly doesn't detect `Get-Item function:Function` as usage
+. $PSScriptRoot\Get-CurrentPesterScope.ps1 # shelly: allow unused-imports
 
 class UnsupportedPesterTestNameException : System.Exception {
     UnsupportedPesterTestNameException([string] $msg) : base($msg) {}

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -1,8 +1,7 @@
 . $PSScriptRoot\..\CIScripts\Common\Invoke-UntilSucceeds.ps1
 . $PSScriptRoot\..\CIScripts\Common\Invoke-NativeCommand.ps1
 . $PSScriptRoot\..\CIScripts\Common\Invoke-CommandWithFunctions.ps1
-# [Shelly-Bug] Shelly doesn't detect imported classes yet.
-. $PSScriptRoot\..\CIScripts\Testenv\Testenv.ps1 # allow unused-imports
+. $PSScriptRoot\..\CIScripts\Testenv\Testenv.ps1
 . $PSScriptRoot\..\CIScripts\Testenv\Testbed.ps1
 
 . $PSScriptRoot\Utils\ComputeNode\Configuration.ps1

--- a/Test/Utils/ComputeNode/Configuration.ps1
+++ b/Test/Utils/ComputeNode/Configuration.ps1
@@ -1,8 +1,7 @@
 . $PSScriptRoot\..\..\..\CIScripts\Common\Init.ps1
 . $PSScriptRoot\..\..\..\CIScripts\Common\Invoke-CommandWithFunctions.ps1
 
-# [Shelly-Bug] Shelly doesn't detect imported classes yet.
-. $PSScriptRoot\..\..\..\CIScripts\Testenv\Testenv.ps1 # allow unused-imports
+. $PSScriptRoot\..\..\..\CIScripts\Testenv\Testenv.ps1
 . $PSScriptRoot\..\..\..\CIScripts\Testenv\Testbed.ps1
 
 . $PSScriptRoot\..\..\Utils\NetAdapterInfo\RemoteHost.ps1

--- a/Test/Utils/ComputeNode/Initialize.ps1
+++ b/Test/Utils/ComputeNode/Initialize.ps1
@@ -1,5 +1,4 @@
-# [Shelly-Bug] Shelly doesn't detect imported classes yet.
-. $PSScriptRoot\..\..\..\CIScripts\Testenv\Testenv.ps1 # allow unused-imports
+. $PSScriptRoot\..\..\..\CIScripts\Testenv\Testenv.ps1
 
 . $PSScriptRoot\..\..\PesterLogger\PesterLogger.ps1
 . $PSScriptRoot\..\..\TestConfigurationUtils.ps1

--- a/Test/Utils/NetAdapterInfo/RemoteHost.ps1
+++ b/Test/Utils/NetAdapterInfo/RemoteHost.ps1
@@ -1,6 +1,5 @@
 . $PSScriptRoot\..\..\..\CIScripts\Common\Aliases.ps1
-# [Shelly-Bug] Shelly doesn't detect imported classes yet.
-. $PSScriptRoot\Impl.ps1 # allow unused-imports
+. $PSScriptRoot\Impl.ps1
 
 function Get-RemoteNetAdapterInformation {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,

--- a/Test/Utils/NetAdapterInfo/RemoteVM.ps1
+++ b/Test/Utils/NetAdapterInfo/RemoteVM.ps1
@@ -1,7 +1,6 @@
 . $PSScriptRoot\..\..\..\CIScripts\Common\Aliases.ps1
 . $PSScriptRoot\..\..\..\CIScripts\Common\Init.ps1
-# [Shelly-Bug] Shelly doesn't detect imported classes yet.
-. $PSScriptRoot\Impl.ps1 # allow unused-imports
+. $PSScriptRoot\Impl.ps1
 
 function Get-RemoteVMNetAdapterInformation {
     Param ([Parameter(Mandatory = $true)] [PSSessionT] $Session,


### PR DESCRIPTION
Reverts some annotations introduced in #334 