### PR TITLE
Check if default configuration folder exists

### DIFF
--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -326,6 +326,11 @@ function Initialize-ComputeServices {
             [Parameter(Mandatory = $true)] [OpenStackConfig] $OpenStackConfig,
             [Parameter(Mandatory = $true)] [ControllerConfig] $ControllerConfig
         )
+
+        if (-not (Test-Path $(Get-DefaultConfigDir)) {
+            New-Item -ItemType Directory -Path $(Get-DefaultConfigDir) -Force
+        }
+
         New-CNMPluginConfigFile -Session $Session `
             -AdapterName $SystemConfig.AdapterName `
             -OpenStackConfig $OpenStackConfig `

--- a/Test/TestConfigurationUtils.ps1
+++ b/Test/TestConfigurationUtils.ps1
@@ -327,7 +327,7 @@ function Initialize-ComputeServices {
             [Parameter(Mandatory = $true)] [ControllerConfig] $ControllerConfig
         )
 
-        if (-not (Test-Path $(Get-DefaultConfigDir)) {
+        if (-not (Test-Path $(Get-DefaultConfigDir))) {
             New-Item -ItemType Directory -Path $(Get-DefaultConfigDir) -Force
         }
 

--- a/Test/Utils/ComputeNode/Configuration.ps1
+++ b/Test/Utils/ComputeNode/Configuration.ps1
@@ -6,12 +6,20 @@
 
 . $PSScriptRoot\..\..\Utils\NetAdapterInfo\RemoteHost.ps1
 
+function Get-DefaultConfigDir {
+    return "C:\ProgramData\Contrail\etc\contrail"
+}
+
 function Get-DefaultCNMPluginsConfigPath {
-    return "C:\ProgramData\Contrail\etc\contrail\contrail-cnm-plugin.conf"
+    return Join-Path $(Get-DefaultConfigDir) "contrail-cnm-plugin.conf"
 }
 
 function Get-DefaultAgentConfigPath {
-    return "C:\ProgramData\Contrail\etc\contrail\contrail-vrouter-agent.conf"
+    return Join-Path $(Get-DefaultConfigDir) "contrail-vrouter-agent.conf"
+}
+
+function Get-DefaultNodeMgrsConfigPath {
+    return Join-Path $(Get-DefaultConfigDir) "contrail-vrouter-nodemgr.conf"
 }
 
 function New-CNMPluginConfigFile {
@@ -49,11 +57,6 @@ Os_token=
         Set-Content -Path $Using:ConfigPath -Value $Using:Config
     }
 }
-
-function Get-DefaultNodeMgrsConfigPath {
-    return "C:\ProgramData\Contrail\etc\contrail\contrail-vrouter-nodemgr.conf"
-}
-
 
 function Get-NodeManagementIP {
     Param([Parameter(Mandatory = $true)] [PSSessionT] $Session)


### PR DESCRIPTION
Right now, agent's msi creates directory which holds configuration files and with [this](https://review.opencontrail.org/#/c/47189/) it will no more, so let's create the directory in CI.