### PR TITLE
Bump Python requirements due to CVEs

### DIFF
--- a/ansible/python-requirements.txt
+++ b/ansible/python-requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.4.2.0
+ansible==2.4.5.0
 ansible-lint==3.4.21
 asn1crypto==0.23.0
 bcrypt==3.1.4
@@ -11,15 +11,15 @@ Jinja2==2.10
 MarkupSafe==1.0
 netaddr==0.7.19
 ntlm-auth==1.0.6
-paramiko==2.3.2
+paramiko==2.3.3
 pyasn1==0.3.7
 pycparser==2.18
 PyNaCl==1.1.2
-pyOpenSSL==17.3.0
+pyOpenSSL==17.5.0
 pyvmomi==6.5.0.2017.5.post1
 pywinrm==0.2.2
 PyYAML==3.12
-requests==2.18.4
+requests==2.20.0
 requests-credssp==0.1.0
 requests-ntlm==1.1.0
 six==1.11.0

--- a/monitoring/requirements.txt
+++ b/monitoring/requirements.txt
@@ -1,6 +1,6 @@
 SQLAlchemy==1.2.3
 mysqlclient==1.3.12
-requests==2.18.4
+requests==2.20.0
 requests-mock==1.4.0
 grafyaml==0.0.7
 timeout-decorator==0.4.0

--- a/monitoring/requirements_windows.txt
+++ b/monitoring/requirements_windows.txt
@@ -1,3 +1,3 @@
-requests==2.18.4
+requests==2.20.0
 requests-mock==1.4.0
 timeout-decorator==0.4.0


### PR DESCRIPTION
GitHub scanner reported the following issues:

- `paramiko>=2.3.3` - https://nvd.nist.gov/vuln/detail/CVE-2018-1000805;
- `pyopenssl>=17.5.0` - https://nvd.nist.gov/vuln/detail/CVE-2018-1000807,
  https://nvd.nist.gov/vuln/detail/CVE-2018-1000808;
- `ansible>=2.4.5` - https://nvd.nist.gov/vuln/detail/CVE-2018-10855;
- `requests>=2.20.0` - https://nvd.nist.gov/vuln/detail/CVE-2018-18074;