### PR TITLE
Add timeout for udp polling

### DIFF
--- a/Test/Utils/Network/UDPClient.ps1
+++ b/Test/Utils/Network/UDPClient.ps1
@@ -23,7 +23,7 @@ function Assert-IsUDPPortListening {
     '}} while (-not (netstat -ano | Select-String -Pattern $IsListenerPortOpenRegex));') -f $PortNumber, $MaxNetstatInvocationCount, $ContainerName
 
     Write-Log "Polling for port $PortNumber on container $ContainerName"
-    Invoke-UntilSucceeds -Duration $Timeout {
+    Invoke-UntilSucceeds -Duration $Timeout -AssumeTrue {
         Invoke-Command -Session $Session -ScriptBlock {
             docker exec $Using:ContainerName powershell "$Using:AssertCommand"
         }

--- a/Test/Utils/Network/UDPClient.ps1
+++ b/Test/Utils/Network/UDPClient.ps1
@@ -1,11 +1,13 @@
 . $PSScriptRoot\..\..\PesterLogger\PesterLogger.ps1
+. $PSScriptRoot\..\..\..\CIScripts\Common\Invoke-UntilSucceeds.ps1
 
 function Assert-IsUDPPortListening {
     Param (
         [Parameter(Mandatory=$true)] [PSSessionT] $Session,
         [Parameter(Mandatory=$true)] [String] $ContainerName,
         [Parameter(Mandatory=$true)] [Int16] $PortNumber,
-        [Parameter(Mandatory=$false)] [Int16] $MaxNetstatInvocationCount = 100
+        [Parameter(Mandatory=$false)] [Int16] $MaxNetstatInvocationCount = 100,
+        [Parameter(Mandatory=$false)] [Int16] $Timeout = 600
     )
 
     # The do-while loop is workaround for slow listener port start,
@@ -20,8 +22,11 @@ function Assert-IsUDPPortListening {
     '   Start-Sleep -Seconds 1;' + `
     '}} while (-not (netstat -ano | Select-String -Pattern $IsListenerPortOpenRegex));') -f $PortNumber, $MaxNetstatInvocationCount, $ContainerName
 
-    Invoke-Command -Session $Session -ScriptBlock {
-        docker exec $Using:ContainerName powershell "$Using:AssertCommand"
+    Write-Log "Polling for port $PortNumber on container $ContainerName"
+    Invoke-UntilSucceeds -Duration $Timeout {
+        Invoke-Command -Session $Session -ScriptBlock {
+            docker exec $Using:ContainerName powershell "$Using:AssertCommand"
+        }
     } | Out-Null
 }
 function Send-UDPFromContainer {


### PR DESCRIPTION
Sometimes docker hangs and because `docker exec` is blocking operation, job is aborted because of timeout.