### PR TITLE
Test script run in jenkins exit 0 when tests pass

### DIFF
--- a/CIScripts/Test.ps1
+++ b/CIScripts/Test.ps1
@@ -10,10 +10,15 @@ Param(
 
 $Job = [Job]::new("Test")
 
-. $PSScriptRoot\..\Test\Invoke-ProductTests.ps1 `
-    -TestRootDir $TestRootDir `
-    -TestReportDir $TestReportDir `
-    -TestenvConfFile $TestenvConfFile `
-    -SmokeTestsOnly:$(!$Nightly)
+try {
+    . $PSScriptRoot\..\Test\Invoke-ProductTests.ps1 `
+        -TestRootDir $TestRootDir `
+        -TestReportDir $TestReportDir `
+        -TestenvConfFile $TestenvConfFile `
+        -SmokeTestsOnly:$(!$Nightly)
+}
+finally {
+    $Job.Done()
+}
 
-$Job.Done()
+exit 0

--- a/CIScripts/Test.ps1
+++ b/CIScripts/Test.ps1
@@ -17,8 +17,13 @@ try {
         -TestenvConfFile $TestenvConfFile `
         -SmokeTestsOnly:$(!$Nightly)
 }
+catch {
+    Write-Host 'Invoke-ProductTests.ps1 has thrown an exception'
+    throw
+}
 finally {
     $Job.Done()
 }
 
+$Error.Clear()
 exit 0


### PR DESCRIPTION
Without exit 0 at the end of script jenkins will fail if something
has been written in error stream. Exceptions will still cause job
to fail, because they will prevent exit 0 from being executed.