### PR TITLE
Dockerfile to build containers parametrized

### DIFF
--- a/CIScripts/Build/Containers.ps1
+++ b/CIScripts/Build/Containers.ps1
@@ -19,7 +19,19 @@ function Invoke-ContainerBuild {
     $ContainerSuffix = $ContainerAttributes.Suffix
     New-Item -Name $WorkDir\$ContainerSuffix\Art -ItemType directory
     Copy-Item -Path $ContainerAttributes.Folders -Destination $WorkDir\$ContainerSuffix\Art -Recurse
-    $BaseImage = 'microsoft/nanoserver'
+
+    switch -regex ((Get-CimInstance Win32_OperatingSystem).Caption) {
+        'Windows Server 2016' {
+            $BaseImage = 'microsoft/nanoserver'
+        }
+        'Windows Server 2019' {
+            $BaseImage = 'mcr.microsoft.com/windows/nanoserver:1809'
+        }
+        Default {
+            throw 'Unknow Windows Server version'
+        }
+    }
+
     $DockerFile = @"
 # escape=``
 FROM $BaseImage

--- a/CIScripts/Build/Containers.ps1
+++ b/CIScripts/Build/Containers.ps1
@@ -21,7 +21,7 @@ function Invoke-ContainerBuild {
     Copy-Item -Path $ContainerAttributes.Folders -Destination $WorkDir\$ContainerSuffix\Art -Recurse
     $BaseImage = 'microsoft/nanoserver'
     $DockerFile = @"
-# escape=`
+# escape=``
 FROM $BaseImage
 
 COPY Art C:\Art

--- a/CIScripts/Build/Dockerfile
+++ b/CIScripts/Build/Dockerfile
@@ -1,8 +1,0 @@
-# escape=`
-FROM microsoft/nanoserver
-
-COPY artifacts.zip C:\
-VOLUME C:\artifacts
-
-CMD powershell -Command `
-    Expand-Archive -Force -Path C:\artifacts.zip -DestinationPath C:\artifacts\


### PR DESCRIPTION
For Windows Server 2019 we will need to use other base images for
containers, that's why we need to parametrize Dockerfile.

Also on WS 2019, nanoserver doesn't have powershell, so we cannot
unpack zip with artifacts.